### PR TITLE
feat(rpc): account nonce lookup rpc added

### DIFF
--- a/idl/rpc.x
+++ b/idl/rpc.x
@@ -171,4 +171,36 @@ namespace mazzaroth
     NOT_FOUND = 2
   };
 
+  // Request for a node to look up an account nonce.
+  struct AccountNonceLookupRequest 
+  {
+    // ID of the account
+    ID account;
+  };
+
+  // Response to account nonce lookup request.
+  struct AccountNonceLookupResponse
+  {
+    // Final receipt written to the blockchain.
+    unsigned hyper nonce; 
+
+    // Status of the lookup
+    NonceLookupStatus status;
+
+    // Human readable information to help understand the status.
+    StatusInfo statusInfo;
+  };
+
+  // Status of a nonce lookup.
+  enum NonceLookupStatus
+  {
+    // The status is either not known or not set.
+    UNKNOWN = 0,
+
+    // The account nonce was found.
+    FOUND = 1,
+
+    // The account nonce was not found.
+    NOT_FOUND = 2
+  };
 }

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -149,6 +149,8 @@ var types = XDR.config(xdr => {
   xdr.struct("TransactionSubmitResponse", [["transactionID", xdr.lookup("ID")], ["status", xdr.lookup("TransactionStatus")], ["statusInfo", xdr.lookup("StatusInfo")]]);
   xdr.struct("ReceiptLookupRequest", [["transactionID", xdr.lookup("ID")]]);
   xdr.struct("ReceiptLookupResponse", [["receipt", xdr.lookup("Receipt")], ["status", xdr.lookup("ReceiptLookupStatus")], ["statusInfo", xdr.lookup("StatusInfo")]]);
+  xdr.struct("AccountNonceLookupRequest", [["account", xdr.lookup("ID")]]);
+  xdr.struct("AccountNonceLookupResponse", [["nonce", xdr.uhyper()], ["status", xdr.lookup("NonceLookupStatus")], ["statusInfo", xdr.lookup("StatusInfo")]]);
 
   // End struct section
 
@@ -188,6 +190,15 @@ var types = XDR.config(xdr => {
   });
 
   xdr.enum("ReceiptLookupStatus", {
+
+    UNKNOWN: 0,
+
+    FOUND: 1,
+
+    NOT_FOUND: 2
+  });
+
+  xdr.enum("NonceLookupStatus", {
 
     UNKNOWN: 0,
 

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -647,6 +647,54 @@ var (
 	_ encoding.BinaryUnmarshaler = (*ReceiptLookupResponse)(nil)
 )
 
+type AccountNonceLookupRequest struct {
+	Account ID
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s AccountNonceLookupRequest) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *AccountNonceLookupRequest) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*AccountNonceLookupRequest)(nil)
+	_ encoding.BinaryUnmarshaler = (*AccountNonceLookupRequest)(nil)
+)
+
+type AccountNonceLookupResponse struct {
+	Nonce uint64
+
+	Status NonceLookupStatus
+
+	StatusInfo StatusInfo
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s AccountNonceLookupResponse) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *AccountNonceLookupResponse) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*AccountNonceLookupResponse)(nil)
+	_ encoding.BinaryUnmarshaler = (*AccountNonceLookupResponse)(nil)
+)
+
 // End struct section
 
 // Start enum section
@@ -861,6 +909,56 @@ func (s *ReceiptLookupStatus) UnmarshalBinary(inp []byte) error {
 var (
 	_ encoding.BinaryMarshaler   = (*ReceiptLookupStatus)(nil)
 	_ encoding.BinaryUnmarshaler = (*ReceiptLookupStatus)(nil)
+)
+
+type NonceLookupStatus int32
+
+const (
+	NonceLookupStatusUNKNOWN NonceLookupStatus = 0
+
+	NonceLookupStatusFOUND NonceLookupStatus = 1
+
+	NonceLookupStatusNOT_FOUND NonceLookupStatus = 2
+)
+
+var NonceLookupStatusMap = map[int32]string{
+
+	0: "NonceLookupStatusUNKNOWN",
+
+	1: "NonceLookupStatusFOUND",
+
+	2: "NonceLookupStatusNOT_FOUND",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for NonceLookupStatus
+func (s NonceLookupStatus) ValidEnum(v int32) bool {
+	_, ok := NonceLookupStatusMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (s NonceLookupStatus) String() string {
+	name, _ := NonceLookupStatusMap[int32(s)]
+	return name
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s NonceLookupStatus) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *NonceLookupStatus) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*NonceLookupStatus)(nil)
+	_ encoding.BinaryUnmarshaler = (*NonceLookupStatus)(nil)
 )
 
 // End enum section


### PR DESCRIPTION
Add RPC definitions for Account Nonce Lookup.

Users/Clients will need a way to check account nonce for an address so that transactions can be properly assigned a Nonce.

Request takes an Address ID and reply includes the nonce and lookup status.