### PR TITLE
Contract metadata

### DIFF
--- a/idl/contract.x
+++ b/idl/contract.x
@@ -7,7 +7,6 @@ namespace mazzaroth
   struct ContractMetadata
   {
     Hash hash;
-    ID owner;
     unsigned hyper version;
   };
 }

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -89,7 +89,7 @@ var types = XDR.config(xdr => {
   // End typedef section
 
   // Start struct section
-  xdr.struct("ContractMetadata", [["hash", xdr.lookup("Hash")], ["owner", xdr.lookup("ID")], ["version", xdr.uhyper()]]);
+  xdr.struct("ContractMetadata", [["hash", xdr.lookup("Hash")], ["version", xdr.uhyper()]]);
 
   // End struct section
 

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -259,8 +259,6 @@ var (
 type ContractMetadata struct {
 	Hash Hash
 
-	Owner ID
-
 	Version uint64
 }
 


### PR DESCRIPTION
Added Contract Metadata object for storing metadata in the Rothvm state.

Object has 3 fields
- Hash - Hash for storing a hash of the contract data in state.
- Owner - ID of the account that created the contract.
- Version - Unsigned Int incrementing version number of the contract for tracking changes.