### PR TITLE
Readonly Request RPC

### DIFF
--- a/idl/rpc.x
+++ b/idl/rpc.x
@@ -117,15 +117,15 @@ namespace mazzaroth
     StatusInfo statusInfo;
   };
 
-  // Message sent to a node to submit a readonly transaction.
-  struct TransactionReadonlyRequest
+  // Message sent to a node to submit a readonly request.
+  struct ReadonlyRequest
   {
     // Reaonly Request can only be a call
     Call call;
   };
 
-  // Response from a node for a readonly transaction Request.
-  struct TransactionReadonlyResponse
+  // Response from a node for a readonly request.
+  struct ReadonlyResponse
   {
     // Return results of execution
     opaque result<>;
@@ -133,8 +133,8 @@ namespace mazzaroth
     // The state root
     Hash stateRoot;
 
-    // Status of the transaction.
-    TransactionStatus status;
+    // Status of the request.
+    ReadonlyStatus status;
 
     // Human readable information to help understand the transaction status.
     StatusInfo statusInfo;
@@ -143,7 +143,6 @@ namespace mazzaroth
   // Status of a transaction.
   enum TransactionStatus
   {
-
     // The transaction status is either not known or not set.
     UNKNOWN = 0,
 
@@ -159,6 +158,19 @@ namespace mazzaroth
 
     // This transaction was not found.
     NOT_FOUND = 4
+  };
+
+  // Status of a readonly request.
+  enum ReadonlyStatus
+  {
+    // The status is either not known or not set.
+    UNKNOWN = 0,
+
+    // Readonly request was successfully executed.
+    SUCCESS = 1,
+
+    // Readonly request did not execute successfully.
+    FAILURE = 2,
   };
 
   // Request for a node to look up a transaction receipt.

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -207,8 +207,8 @@ var types = XDR.config(xdr => {
   xdr.struct("TransactionLookupResponse", [["transaction", xdr.lookup("Transaction")], ["status", xdr.lookup("TransactionStatus")], ["statusInfo", xdr.lookup("StatusInfo")]]);
   xdr.struct("TransactionSubmitRequest", [["transaction", xdr.lookup("Transaction")]]);
   xdr.struct("TransactionSubmitResponse", [["transactionID", xdr.lookup("ID")], ["status", xdr.lookup("TransactionStatus")], ["statusInfo", xdr.lookup("StatusInfo")]]);
-  xdr.struct("TransactionReadonlyRequest", [["call", xdr.lookup("Call")]]);
-  xdr.struct("TransactionReadonlyResponse", [["result", xdr.varOpaque()], ["stateRoot", xdr.lookup("Hash")], ["status", xdr.lookup("TransactionStatus")], ["statusInfo", xdr.lookup("StatusInfo")]]);
+  xdr.struct("ReadonlyRequest", [["call", xdr.lookup("Call")]]);
+  xdr.struct("ReadonlyResponse", [["result", xdr.varOpaque()], ["stateRoot", xdr.lookup("Hash")], ["status", xdr.lookup("ReadonlyStatus")], ["statusInfo", xdr.lookup("StatusInfo")]]);
   xdr.struct("ReceiptLookupRequest", [["transactionID", xdr.lookup("ID")]]);
   xdr.struct("ReceiptLookupResponse", [["receipt", xdr.lookup("Receipt")], ["status", xdr.lookup("ReceiptLookupStatus")], ["statusInfo", xdr.lookup("StatusInfo")]]);
   xdr.struct("AccountNonceLookupRequest", [["account", xdr.lookup("ID")]]);
@@ -249,6 +249,15 @@ var types = XDR.config(xdr => {
     CONFIRMED: 3,
 
     NOT_FOUND: 4
+  });
+
+  xdr.enum("ReadonlyStatus", {
+
+    UNKNOWN: 0,
+
+    SUCCESS: 1,
+
+    FAILURE: 2
   });
 
   xdr.enum("ReceiptLookupStatus", {

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -839,54 +839,54 @@ var (
 	_ encoding.BinaryUnmarshaler = (*TransactionSubmitResponse)(nil)
 )
 
-type TransactionReadonlyRequest struct {
+type ReadonlyRequest struct {
 	Call Call
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s TransactionReadonlyRequest) MarshalBinary() ([]byte, error) {
+func (s ReadonlyRequest) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *TransactionReadonlyRequest) UnmarshalBinary(inp []byte) error {
+func (s *ReadonlyRequest) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*TransactionReadonlyRequest)(nil)
-	_ encoding.BinaryUnmarshaler = (*TransactionReadonlyRequest)(nil)
+	_ encoding.BinaryMarshaler   = (*ReadonlyRequest)(nil)
+	_ encoding.BinaryUnmarshaler = (*ReadonlyRequest)(nil)
 )
 
-type TransactionReadonlyResponse struct {
+type ReadonlyResponse struct {
 	Result []byte
 
 	StateRoot Hash
 
-	Status TransactionStatus
+	Status ReadonlyStatus
 
 	StatusInfo StatusInfo
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (s TransactionReadonlyResponse) MarshalBinary() ([]byte, error) {
+func (s ReadonlyResponse) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
 	_, err := Marshal(b, s)
 	return b.Bytes(), err
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *TransactionReadonlyResponse) UnmarshalBinary(inp []byte) error {
+func (s *ReadonlyResponse) UnmarshalBinary(inp []byte) error {
 	_, err := Unmarshal(bytes.NewReader(inp), s)
 	return err
 }
 
 var (
-	_ encoding.BinaryMarshaler   = (*TransactionReadonlyResponse)(nil)
-	_ encoding.BinaryUnmarshaler = (*TransactionReadonlyResponse)(nil)
+	_ encoding.BinaryMarshaler   = (*ReadonlyResponse)(nil)
+	_ encoding.BinaryUnmarshaler = (*ReadonlyResponse)(nil)
 )
 
 type ReceiptLookupRequest struct {
@@ -1149,6 +1149,56 @@ func (s *TransactionStatus) UnmarshalBinary(inp []byte) error {
 var (
 	_ encoding.BinaryMarshaler   = (*TransactionStatus)(nil)
 	_ encoding.BinaryUnmarshaler = (*TransactionStatus)(nil)
+)
+
+type ReadonlyStatus int32
+
+const (
+	ReadonlyStatusUNKNOWN ReadonlyStatus = 0
+
+	ReadonlyStatusSUCCESS ReadonlyStatus = 1
+
+	ReadonlyStatusFAILURE ReadonlyStatus = 2
+)
+
+var ReadonlyStatusMap = map[int32]string{
+
+	0: "ReadonlyStatusUNKNOWN",
+
+	1: "ReadonlyStatusSUCCESS",
+
+	2: "ReadonlyStatusFAILURE",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for ReadonlyStatus
+func (s ReadonlyStatus) ValidEnum(v int32) bool {
+	_, ok := ReadonlyStatusMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (s ReadonlyStatus) String() string {
+	name, _ := ReadonlyStatusMap[int32(s)]
+	return name
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s ReadonlyStatus) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *ReadonlyStatus) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*ReadonlyStatus)(nil)
+	_ encoding.BinaryUnmarshaler = (*ReadonlyStatus)(nil)
 )
 
 type ReceiptLookupStatus int32


### PR DESCRIPTION
Added Transaction Readonly Request and Response objects for new Readonly RPC.

Request uses the same Transaction object and Response includes the Transaction Receipt along with status info.