### PR TITLE
feat(plan): adding an execution plan to mazzaroth xdr

### DIFF
--- a/idl/plan.x
+++ b/idl/plan.x
@@ -1,0 +1,14 @@
+
+namespace mazzaroth
+{
+
+  struct ExecutionPlan 
+  {
+    string host<256>;
+
+    ID channelID;
+
+    Call calls<100>;      
+  };
+
+}

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -16,6 +16,7 @@ exports.Hash = Hash;
 exports.Parameter = Parameter;
 exports.ContractMetadata = ContractMetadata;
 exports.Event = Event;
+exports.ExecutionPlan = ExecutionPlan;
 exports.Receipt = Receipt;
 exports.ReceiptStatus = ReceiptStatus;
 exports.StatusInfo = StatusInfo;
@@ -215,6 +216,29 @@ function ContractMetadata() {
 // Start struct section
 function Event() {
     return new _jsXdr2.default.Struct(["key", "parameters"], [new _jsXdr2.default.Str(256), new _jsXdr2.default.VarArray(2147483647, Parameter)]);
+}
+
+// End struct section
+
+// Start enum section
+
+
+// End enum section
+
+// Start union section
+
+
+// End union section
+
+// End namespace mazzaroth
+// Namespace start mazzaroth
+
+// Start typedef section
+// End typedef section
+
+// Start struct section
+function ExecutionPlan() {
+    return new _jsXdr2.default.Struct(["host", "channelID", "calls"], [new _jsXdr2.default.Str(256), ID(), new _jsXdr2.default.VarArray(100, Call)]);
 }
 
 // End struct section

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -5,7 +5,6 @@ extern crate ex_dee_derive;
 use ex_dee::de::{read_fixed_array, read_var_array, read_var_string, XDRIn};
 use ex_dee::error::Error;
 use ex_dee::ser::{write_fixed_array, write_var_array, write_var_string, XDROut};
-use std::io::{Read, Write};
 
 // Namspace start mazzaroth
 
@@ -196,6 +195,32 @@ pub struct Event {
 
     #[array(var = 2147483647)]
     pub parameters: Vec<Parameter>,
+}
+
+// End struct section
+
+// Start union section
+
+// End union section
+
+// Namspace end mazzaroth
+// Namspace start mazzaroth
+
+// Start typedef section
+
+// End typedef section
+
+// Start struct section
+
+#[derive(Default, Debug, XDROut, XDRIn)]
+pub struct ExecutionPlan {
+    #[array(var = 256)]
+    pub host: String,
+
+    pub channelID: ID,
+
+    #[array(var = 100)]
+    pub calls: Vec<Call>,
 }
 
 // End struct section

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -534,6 +534,48 @@ var (
 // End typedef section
 
 // Start struct section
+type ExecutionPlan struct {
+	Host string `xdrmaxsize:"256"`
+
+	ChannelID ID
+
+	Calls []Call `xdrmaxsize:"100"`
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s ExecutionPlan) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *ExecutionPlan) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*ExecutionPlan)(nil)
+	_ encoding.BinaryUnmarshaler = (*ExecutionPlan)(nil)
+)
+
+// End struct section
+
+// Start enum section
+
+// End enum section
+//
+// Start union section
+// End union section
+
+// Namspace end mazzaroth
+// Namspace start mazzaroth
+
+// Start typedef section
+// End typedef section
+
+// Start struct section
 type Receipt struct {
 	Status ReceiptStatus
 


### PR DESCRIPTION
We need a data structure that encodes a series of transactions to
execute to a particular channel. The primary use case will be out of
band execution of transactions through a secure wallet.

One specific use case would be encoding this data as a QR code and
presenting it to a user from a website to allowing them to execute
transactions from a secure wallet app without exposing their private
accout key.

Breaks nothing