### PR TITLE
Account fixes and lookup

### DIFF
--- a/idl/rpc.x
+++ b/idl/rpc.x
@@ -9,7 +9,7 @@ namespace mazzaroth
 
   struct StateStatus
   {
-    Hash previousBlock;
+    unsigned hyper previousBlock;
 
     unsigned hyper transactionCount;
 

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -299,7 +299,7 @@ function StatusInfo() {
 
 // Start struct section
 function StateStatus() {
-    return new _jsXdr2.default.Struct(["previousBlock", "transactionCount"], [Hash(), new _jsXdr2.default.UHyper()]);
+    return new _jsXdr2.default.Struct(["previousBlock", "transactionCount"], [new _jsXdr2.default.UHyper(), new _jsXdr2.default.UHyper()]);
 }
 function BlockLookupRequest() {
     return new _jsXdr2.default.Struct(["ID"], [Identifier()]);

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -285,7 +285,7 @@ pub struct StatusInfo {
 
 #[derive(Default, Debug, XDROut, XDRIn)]
 pub struct StateStatus {
-    pub previousBlock: Hash,
+    pub previousBlock: u64,
 
     pub transactionCount: u64,
 }

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -688,7 +688,7 @@ var (
 
 // Start struct section
 type StateStatus struct {
-	PreviousBlock Hash
+	PreviousBlock uint64
 
 	TransactionCount uint64
 }


### PR DESCRIPTION
All transactions that don't hit the consenus network (lookups and readonly transactions) should give some indication of what the current state is for the readonly node. Returning StateStatus for each of these rpcs is the current solution.

Also adding an a node rpc for looking up account info generally.