### PR TITLE
fix: xdrgen was not generating js Str types correctly

### DIFF
--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -72,7 +72,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 // Start struct section
 function Account() {
-    return new _jsXdr2.default.Struct(["name", "nonce", "permissionedKeys"], [new _jsXdr2.default.Str(0), new _jsXdr2.default.UHyper(), new _jsXdr2.default.VarArray(2147483647, ID)]);
+    return new _jsXdr2.default.Struct(["name", "nonce", "permissionedKeys"], [new _jsXdr2.default.Str('', 0), new _jsXdr2.default.UHyper(), new _jsXdr2.default.VarArray(2147483647, ID)]);
 }
 
 // End struct section
@@ -98,7 +98,7 @@ function Block() {
     return new _jsXdr2.default.Struct(["header", "transactions"], [BlockHeader(), new _jsXdr2.default.VarArray(2147483647, Transaction)]);
 }
 function BlockHeader() {
-    return new _jsXdr2.default.Struct(["timestamp", "blockHeight", "txMerkleRoot", "txReceiptRoot", "stateRoot", "previousHeader", "blockProducerAddress"], [new _jsXdr2.default.Str(256), new _jsXdr2.default.UHyper(), Hash(), Hash(), Hash(), Hash(), ID()]);
+    return new _jsXdr2.default.Struct(["timestamp", "blockHeight", "txMerkleRoot", "txReceiptRoot", "stateRoot", "previousHeader", "blockProducerAddress"], [new _jsXdr2.default.Str('', 256), new _jsXdr2.default.UHyper(), Hash(), Hash(), Hash(), Hash(), ID()]);
 }
 
 // End struct section
@@ -223,7 +223,7 @@ function ContractMetadata() {
 
 // Start struct section
 function Event() {
-    return new _jsXdr2.default.Struct(["key", "parameters"], [new _jsXdr2.default.Str(256), new _jsXdr2.default.VarArray(2147483647, Parameter)]);
+    return new _jsXdr2.default.Struct(["key", "parameters"], [new _jsXdr2.default.Str('', 256), new _jsXdr2.default.VarArray(2147483647, Parameter)]);
 }
 
 // End struct section
@@ -246,7 +246,7 @@ function Event() {
 
 // Start struct section
 function ExecutionPlan() {
-    return new _jsXdr2.default.Struct(["host", "channelID", "calls"], [new _jsXdr2.default.Str(256), ID(), new _jsXdr2.default.VarArray(100, Call)]);
+    return new _jsXdr2.default.Struct(["host", "channelID", "calls"], [new _jsXdr2.default.Str('', 256), ID(), new _jsXdr2.default.VarArray(100, Call)]);
 }
 
 // End struct section
@@ -297,7 +297,7 @@ function ReceiptStatus() {
 // Start typedef section
 
 function StatusInfo() {
-    return new _jsXdr2.default.Str(256);
+    return new _jsXdr2.default.Str('', 256);
 }
 // End typedef section
 
@@ -451,7 +451,7 @@ function Identifier() {
 
 // Start struct section
 function Call() {
-    return new _jsXdr2.default.Struct(["function", "parameters"], [new _jsXdr2.default.Str(256), new _jsXdr2.default.VarArray(2147483647, Parameter)]);
+    return new _jsXdr2.default.Struct(["function", "parameters"], [new _jsXdr2.default.Str('', 256), new _jsXdr2.default.VarArray(2147483647, Parameter)]);
 }
 function Update() {
     return new _jsXdr2.default.Struct(["contract"], [new _jsXdr2.default.VarOpaque(2147483647)]);
@@ -469,7 +469,7 @@ function CommittedTransaction() {
     return new _jsXdr2.default.Struct(["transaction", "sequenceNumber", "receiptID", "currentTransactionRoot", "signatures"], [Transaction(), new _jsXdr2.default.UHyper(), new _jsXdr2.default.VarArray(25, ID), Hash(), new _jsXdr2.default.VarArray(2147483647, Signature)]);
 }
 function Input() {
-    return new _jsXdr2.default.Struct(["inputType", "function", "parameters"], [InputType(), new _jsXdr2.default.Str(256), new _jsXdr2.default.VarArray(2147483647, Parameter)]);
+    return new _jsXdr2.default.Struct(["inputType", "function", "parameters"], [InputType(), new _jsXdr2.default.Str('', 256), new _jsXdr2.default.VarArray(2147483647, Parameter)]);
 }
 
 // End struct section

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -2,8 +2,10 @@
 #![allow(non_camel_case_types)]
 #[macro_use]
 extern crate ex_dee_derive;
+#[allow(unused_imports)]
 use ex_dee::de::{read_fixed_array, read_var_array, read_var_string, XDRIn};
 use ex_dee::error::Error;
+#[allow(unused_imports)]
 use ex_dee::ser::{write_fixed_array, write_var_array, write_var_string, XDROut};
 
 // Namspace start mazzaroth
@@ -14,7 +16,7 @@ use ex_dee::ser::{write_fixed_array, write_var_array, write_var_string, XDROut};
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Account {
     pub name: String,
 
@@ -39,7 +41,7 @@ pub struct Account {
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Block {
     pub header: BlockHeader,
 
@@ -47,7 +49,7 @@ pub struct Block {
     pub transactions: Vec<Transaction>,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct BlockHeader {
     #[array(var = 256)]
     pub timestamp: String,
@@ -80,7 +82,7 @@ pub struct BlockHeader {
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ChannelConfig {
     pub owner: ID,
 
@@ -90,14 +92,14 @@ pub struct ChannelConfig {
     pub consensusConfig: ConsensusConfig,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct PBFTConfig {
     pub checkpointPeriod: u64,
 }
 
 // End struct section
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum ConsensusConfigType {
     NONE = 0,
     PBFT = 1,
@@ -110,7 +112,7 @@ impl Default for ConsensusConfigType {
 }
 // Start union section
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum ConsensusConfig {
     NONE(()),
 
@@ -129,22 +131,22 @@ impl Default for ConsensusConfig {
 
 // Start typedef section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Signature {
     #[array(fixed = 64)]
     pub t: Vec<u8>,
 }
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ID {
     #[array(fixed = 32)]
     pub t: Vec<u8>,
 }
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Hash {
     #[array(fixed = 32)]
     pub t: Vec<u8>,
 }
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Parameter {
     #[array(var = 2147483647)]
     pub t: Vec<u8>,
@@ -169,7 +171,7 @@ pub struct Parameter {
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ContractMetadata {
     pub hash: Hash,
 
@@ -191,7 +193,7 @@ pub struct ContractMetadata {
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Event {
     #[array(var = 256)]
     pub key: String,
@@ -215,7 +217,7 @@ pub struct Event {
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ExecutionPlan {
     #[array(var = 256)]
     pub host: String,
@@ -241,7 +243,7 @@ pub struct ExecutionPlan {
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Receipt {
     pub status: ReceiptStatus,
 
@@ -256,7 +258,7 @@ pub struct Receipt {
 
 // End struct section
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum ReceiptStatus {
     FAILURE = 0,
     SUCCESS = 1,
@@ -276,7 +278,7 @@ impl Default for ReceiptStatus {
 
 // Start typedef section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct StatusInfo {
     #[array(var = 256)]
     pub t: String,
@@ -286,24 +288,24 @@ pub struct StatusInfo {
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct StateStatus {
     pub previousBlock: u64,
 
     pub transactionCount: u64,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct BlockLookupRequest {
     pub ID: Identifier,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct BlockHeaderLookupRequest {
     pub ID: Identifier,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct BlockLookupResponse {
     pub block: Block,
 
@@ -314,7 +316,7 @@ pub struct BlockLookupResponse {
     pub statusInfo: StatusInfo,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct BlockHeaderLookupResponse {
     pub header: BlockHeader,
 
@@ -325,12 +327,12 @@ pub struct BlockHeaderLookupResponse {
     pub statusInfo: StatusInfo,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct TransactionLookupRequest {
     pub transactionID: ID,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct TransactionLookupResponse {
     pub transaction: Transaction,
 
@@ -341,12 +343,12 @@ pub struct TransactionLookupResponse {
     pub statusInfo: StatusInfo,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct TransactionSubmitRequest {
     pub transaction: Transaction,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct TransactionSubmitResponse {
     pub transactionID: ID,
 
@@ -355,12 +357,12 @@ pub struct TransactionSubmitResponse {
     pub statusInfo: StatusInfo,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ReadonlyRequest {
     pub call: Call,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ReadonlyResponse {
     #[array(var = 2147483647)]
     pub result: Vec<u8>,
@@ -372,12 +374,12 @@ pub struct ReadonlyResponse {
     pub statusInfo: StatusInfo,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ReceiptLookupRequest {
     pub transactionID: ID,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ReceiptLookupResponse {
     pub receipt: Receipt,
 
@@ -388,12 +390,12 @@ pub struct ReceiptLookupResponse {
     pub statusInfo: StatusInfo,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct AccountNonceLookupRequest {
     pub account: ID,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct AccountNonceLookupResponse {
     pub nonce: u64,
 
@@ -404,12 +406,12 @@ pub struct AccountNonceLookupResponse {
     pub statusInfo: StatusInfo,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct AccountInfoLookupRequest {
     pub account: ID,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct AccountInfoLookupResponse {
     pub accountInfo: Account,
 
@@ -422,7 +424,7 @@ pub struct AccountInfoLookupResponse {
 
 // End struct section
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum IdentifierType {
     NONE = 0,
     NUMBER = 1,
@@ -435,7 +437,7 @@ impl Default for IdentifierType {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum BlockStatus {
     UNKNOWN = 0,
     CREATED = 1,
@@ -449,7 +451,7 @@ impl Default for BlockStatus {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum TransactionStatus {
     UNKNOWN = 0,
     ACCEPTED = 1,
@@ -464,7 +466,7 @@ impl Default for TransactionStatus {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum ReadonlyStatus {
     UNKNOWN = 0,
     SUCCESS = 1,
@@ -477,7 +479,7 @@ impl Default for ReadonlyStatus {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum ReceiptLookupStatus {
     UNKNOWN = 0,
     FOUND = 1,
@@ -490,7 +492,7 @@ impl Default for ReceiptLookupStatus {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum NonceLookupStatus {
     UNKNOWN = 0,
     FOUND = 1,
@@ -503,7 +505,7 @@ impl Default for NonceLookupStatus {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum InfoLookupStatus {
     UNKNOWN = 0,
     FOUND = 1,
@@ -517,7 +519,7 @@ impl Default for InfoLookupStatus {
 }
 // Start union section
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum Identifier {
     NONE(()),
 
@@ -542,7 +544,7 @@ impl Default for Identifier {
 
 // Start struct section
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Call {
     #[array(var = 256)]
     pub function: String,
@@ -551,20 +553,20 @@ pub struct Call {
     pub parameters: Vec<Parameter>,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Update {
     #[array(var = 2147483647)]
     pub contract: Vec<u8>,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Permission {
     pub key: ID,
 
     pub action: PermissionAction,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Action {
     pub address: ID,
 
@@ -575,7 +577,7 @@ pub struct Action {
     pub category: ActionCategory,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Transaction {
     pub signature: Signature,
 
@@ -584,7 +586,7 @@ pub struct Transaction {
     pub action: Action,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct CommittedTransaction {
     pub transaction: Transaction,
 
@@ -599,7 +601,7 @@ pub struct CommittedTransaction {
     pub signatures: Vec<Signature>,
 }
 
-#[derive(Default, Debug, XDROut, XDRIn)]
+#[derive(Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Input {
     pub inputType: InputType,
 
@@ -612,7 +614,7 @@ pub struct Input {
 
 // End struct section
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum PermissionAction {
     REVOKE = 0,
     GRANT = 1,
@@ -624,7 +626,7 @@ impl Default for PermissionAction {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum ActionCategoryType {
     NONE = 0,
     CALL = 1,
@@ -638,7 +640,7 @@ impl Default for ActionCategoryType {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum AuthorityType {
     NONE = 0,
     PERMISSIONED = 1,
@@ -650,7 +652,7 @@ impl Default for AuthorityType {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum InputType {
     NONE = 0,
     READONLY = 1,
@@ -665,7 +667,7 @@ impl Default for InputType {
 }
 // Start union section
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum ActionCategory {
     NONE(()),
 
@@ -682,7 +684,7 @@ impl Default for ActionCategory {
     }
 }
 
-#[derive(Debug, XDROut, XDRIn)]
+#[derive(Clone, Debug, XDROut, XDRIn)]
 pub enum Authority {
     NONE(()),
 


### PR DESCRIPTION
Strings were setting their max size as their initial value, which is now
fixed.

Breaks nothing