### PR TITLE
feat(schema): add the schema to the update transaction

### DIFF
--- a/idl/transaction.x
+++ b/idl/transaction.x
@@ -19,6 +19,9 @@ namespace mazzaroth
   {
     // Contract binary bytes.
     opaque contract<>;
+
+    // Schema data format for use with keyquery data formats
+    Schema schema;
   };
 
   enum PermissionAction

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -556,7 +556,7 @@ function Call() {
     return new _xdrJsSerialize2.default.Struct(["function", "parameters"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.VarArray(2147483647, Parameter)]);
 }
 function Update() {
-    return new _xdrJsSerialize2.default.Struct(["contract"], [new _xdrJsSerialize2.default.VarOpaque(2147483647)]);
+    return new _xdrJsSerialize2.default.Struct(["contract", "schema"], [new _xdrJsSerialize2.default.VarOpaque(2147483647), Schema()]);
 }
 function Permission() {
     return new _xdrJsSerialize2.default.Struct(["key", "action"], [ID(), PermissionAction()]);

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -681,6 +681,8 @@ pub struct Call {
 pub struct Update {
     #[array(var = 2147483647)]
     pub contract: Vec<u8>,
+
+    pub schema: Schema,
 }
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -2282,6 +2282,8 @@ var (
 // Update generated struct
 type Update struct {
 	Contract []byte
+
+	Schema Schema
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.


### PR DESCRIPTION
This allows us to upload a schmea alongside our contract if we would
like to use the keyquery features.