### PR TITLE
fix: put a max length on the primary key label

### DIFF
--- a/idl/schema.x
+++ b/idl/schema.x
@@ -72,7 +72,7 @@ namespace mazzaroth
   {
     string name<40>;
 
-    string primary;
+    string primary<40>;
 
     Column columns<40>;
   };

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -481,7 +481,7 @@ function ArrayColumn() {
     return new _xdrJsSerialize2.default.Struct(["name", "fixed", "length", "column"], [new _xdrJsSerialize2.default.Str('', 40), new _xdrJsSerialize2.default.Bool(), new _xdrJsSerialize2.default.UInt(), new _xdrJsSerialize2.default.FixedArray(1, Column)]);
 }
 function Table() {
-    return new _xdrJsSerialize2.default.Struct(["name", "primary", "columns"], [new _xdrJsSerialize2.default.Str('', 40), new _xdrJsSerialize2.default.Str('', 0), new _xdrJsSerialize2.default.VarArray(40, Column)]);
+    return new _xdrJsSerialize2.default.Struct(["name", "primary", "columns"], [new _xdrJsSerialize2.default.Str('', 40), new _xdrJsSerialize2.default.Str('', 40), new _xdrJsSerialize2.default.VarArray(40, Column)]);
 }
 function Schema() {
     return new _xdrJsSerialize2.default.Struct(["tables"], [new _xdrJsSerialize2.default.VarArray(40, Table)]);

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -593,6 +593,7 @@ pub struct Table {
     #[array(var = 40)]
     pub name: String,
 
+    #[array(var = 40)]
     pub primary: String,
 
     #[array(var = 40)]

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -1840,7 +1840,7 @@ var (
 type Table struct {
 	Name string `xdrmaxsize:"40"`
 
-	Primary string
+	Primary string `xdrmaxsize:"40"`
 
 	Columns []Column `xdrmaxsize:"40"`
 }


### PR DESCRIPTION
Safer to have a size limit on our string types