### PR TITLE
Added download protocol objects and updated block object

### DIFF
--- a/idl/block.x
+++ b/idl/block.x
@@ -21,6 +21,9 @@ namespace mazzaroth
     // Block height is the number of blocks preceding this block
     unsigned hyper blockHeight;
 
+    // Ending transaction consensus height of this block
+    unsigned hyper transactionHeight;
+
     // The merkle root of the transaction merkle tree in this block
     Hash txMerkleRoot;
 

--- a/idl/block.x
+++ b/idl/block.x
@@ -21,8 +21,11 @@ namespace mazzaroth
     // Block height is the number of blocks preceding this block
     unsigned hyper blockHeight;
 
-    // Ending transaction consensus height of this block
+    // Ending transaction height of this block
     unsigned hyper transactionHeight;
+
+    // Ending consensus sequence number for commits in this block
+    unsigned hyper consensusSequenceNumber;
 
     // The merkle root of the transaction merkle tree in this block
     Hash txMerkleRoot;

--- a/idl/download.x
+++ b/idl/download.x
@@ -2,7 +2,7 @@
 
 namespace mazzaroth
 {
-    // Downlaod Requests are made between Mazzaroth nodes to sync data
+    // Download Requests are made between Mazzaroth nodes to sync data
     struct DownloadRequest {
         DownloadRequestPayload downloadRequestPayload;
     }

--- a/idl/download.x
+++ b/idl/download.x
@@ -11,7 +11,7 @@ namespace mazzaroth
     enum DownloadRequestType {
         UNKNOWN = 0,
         HEIGHT = 1, // Request current block height of node
-        BLOCK = 2 // Request a block from the node
+        BLOCK = 2 // Request a specific block from the node
     };
 
     union DownloadRequestPayload switch (DownloadRequestType Type)
@@ -21,7 +21,7 @@ namespace mazzaroth
         case HEIGHT:
             void;
         case BLOCK:
-            unsigned hyper height;
+            unsigned hyper blockNumber;
     }
 
     // Download Responses returned from requests

--- a/idl/download.x
+++ b/idl/download.x
@@ -4,7 +4,7 @@ namespace mazzaroth
 {
     // Downlaod Requests are made between Mazzaroth nodes to sync data
     struct DownloadRequest {
-        RequestPayload requestPayload;
+        DownloadRequestPayload downloadRequestPayload;
     }
 
     // The different request messages that can be sent
@@ -26,7 +26,7 @@ namespace mazzaroth
 
     // Download Responses returned from requests
     struct DownloadResponse {
-        ResponsePayload ResponsePayload;
+        DownloadResponsePayload downloadResponsePayload;
     }
 
     union DownloadResponsePayload switch (DownloadRequestType Type)

--- a/idl/download.x
+++ b/idl/download.x
@@ -1,0 +1,41 @@
+%#include "block.x"
+
+namespace mazzaroth
+{
+    // Downlaod Requests are made between Mazzaroth nodes to sync data
+    struct DownloadRequest {
+        RequestPayload requestPayload;
+    }
+
+    // The different request messages that can be sent
+    enum DownloadRequestType {
+        UNKNOWN = 0,
+        HEIGHT = 1, // Request current block height of node
+        BLOCK = 2 // Request a block from the node
+    };
+
+    union DownloadRequestPayload switch (DownloadRequestType Type)
+    {
+        case UNKNOWN:
+            void;
+        case HEIGHT:
+            void;
+        case BLOCK:
+            unsigned hyper height;
+    }
+
+    // Download Responses returned from requests
+    struct DownloadResponse {
+        ResponsePayload ResponsePayload;
+    }
+
+    union DownloadResponsePayload switch (DownloadRequestType Type)
+    {
+        case UNKNOWN:
+            void;
+        case HEIGHT:
+            unsigned hyper height;
+        case BLOCK:
+            Block block;
+    }
+}

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -240,10 +240,10 @@ function ContractMetadata() {
 
 // Start struct section
 function DownloadRequest() {
-    return new _xdrJsSerialize2.default.Struct(["requestPayload"], [RequestPayload()]);
+    return new _xdrJsSerialize2.default.Struct(["DownloadRequestPayload"], [DownloadRequestPayload()]);
 }
 function DownloadResponse() {
-    return new _xdrJsSerialize2.default.Struct(["ResponsePayload"], [ResponsePayload()]);
+    return new _xdrJsSerialize2.default.Struct(["DownloadResponsePayload"], [DownloadResponsePayload()]);
 }
 
 // End struct section

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -15,6 +15,11 @@ exports.ID = ID;
 exports.Hash = Hash;
 exports.Parameter = Parameter;
 exports.ContractMetadata = ContractMetadata;
+exports.DownloadRequest = DownloadRequest;
+exports.DownloadResponse = DownloadResponse;
+exports.DownloadRequestType = DownloadRequestType;
+exports.DownloadRequestPayload = DownloadRequestPayload;
+exports.DownloadResponsePayload = DownloadResponsePayload;
 exports.Event = Event;
 exports.ExecutionPlan = ExecutionPlan;
 exports.Receipt = Receipt;
@@ -224,6 +229,76 @@ function ContractMetadata() {
 
 // Start union section
 
+
+// End union section
+
+// End namespace mazzaroth
+// Namespace start mazzaroth
+
+// Start typedef section
+// End typedef section
+
+// Start struct section
+function DownloadRequest() {
+    return new _xdrJsSerialize2.default.Struct(["requestPayload"], [RequestPayload()]);
+}
+function DownloadResponse() {
+    return new _xdrJsSerialize2.default.Struct(["ResponsePayload"], [ResponsePayload()]);
+}
+
+// End struct section
+
+// Start enum section
+
+function DownloadRequestType() {
+    return new _xdrJsSerialize2.default.Enum({
+        0: "UNKNOWN",
+        1: "HEIGHT",
+        2: "BLOCK"
+
+    });
+}
+
+// End enum section
+
+// Start union section
+
+
+function DownloadRequestPayload() {
+    return new _xdrJsSerialize2.default.Union(DownloadRequestType(), {
+
+        "UNKNOWN": () => {
+            return new _xdrJsSerialize2.default.Void();
+        },
+
+        "HEIGHT": () => {
+            return new _xdrJsSerialize2.default.Void();
+        },
+
+        "BLOCK": () => {
+            return new _xdrJsSerialize2.default.UHyper();
+        }
+
+    });
+}
+
+function DownloadResponsePayload() {
+    return new _xdrJsSerialize2.default.Union(DownloadRequestType(), {
+
+        "UNKNOWN": () => {
+            return new _xdrJsSerialize2.default.Void();
+        },
+
+        "HEIGHT": () => {
+            return new _xdrJsSerialize2.default.UHyper();
+        },
+
+        "BLOCK": () => {
+            return Block();
+        }
+
+    });
+}
 
 // End union section
 

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -111,7 +111,7 @@ function Block() {
     return new _xdrJsSerialize2.default.Struct(["header", "transactions"], [BlockHeader(), new _xdrJsSerialize2.default.VarArray(2147483647, Transaction)]);
 }
 function BlockHeader() {
-    return new _xdrJsSerialize2.default.Struct(["timestamp", "blockHeight", "txMerkleRoot", "txReceiptRoot", "stateRoot", "previousHeader", "blockProducerAddress"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.UHyper(), Hash(), Hash(), Hash(), Hash(), ID()]);
+    return new _xdrJsSerialize2.default.Struct(["timestamp", "blockHeight", "transactionHeight", "txMerkleRoot", "txReceiptRoot", "stateRoot", "previousHeader", "blockProducerAddress"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.UHyper(), Hash(), Hash(), Hash(), Hash(), ID()]);
 }
 
 // End struct section
@@ -240,10 +240,10 @@ function ContractMetadata() {
 
 // Start struct section
 function DownloadRequest() {
-    return new _xdrJsSerialize2.default.Struct(["DownloadRequestPayload"], [DownloadRequestPayload()]);
+    return new _xdrJsSerialize2.default.Struct(["downloadRequestPayload"], [DownloadRequestPayload()]);
 }
 function DownloadResponse() {
-    return new _xdrJsSerialize2.default.Struct(["DownloadResponsePayload"], [DownloadResponsePayload()]);
+    return new _xdrJsSerialize2.default.Struct(["downloadResponsePayload"], [DownloadResponsePayload()]);
 }
 
 // End struct section

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -111,7 +111,7 @@ function Block() {
     return new _xdrJsSerialize2.default.Struct(["header", "transactions"], [BlockHeader(), new _xdrJsSerialize2.default.VarArray(2147483647, Transaction)]);
 }
 function BlockHeader() {
-    return new _xdrJsSerialize2.default.Struct(["timestamp", "blockHeight", "transactionHeight", "txMerkleRoot", "txReceiptRoot", "stateRoot", "previousHeader", "blockProducerAddress"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.UHyper(), Hash(), Hash(), Hash(), Hash(), ID()]);
+    return new _xdrJsSerialize2.default.Struct(["timestamp", "blockHeight", "transactionHeight", "consensusSequenceNumber", "txMerkleRoot", "txReceiptRoot", "stateRoot", "previousHeader", "blockProducerAddress"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.UHyper(), Hash(), Hash(), Hash(), Hash(), ID()]);
 }
 
 // End struct section

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -199,6 +199,72 @@ pub struct ContractMetadata {
 // Start struct section
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
+pub struct DownloadRequest {
+    pub requestPayload: RequestPayload,
+}
+
+#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
+pub struct DownloadResponse {
+    pub ResponsePayload: ResponsePayload,
+}
+
+// End struct section
+
+#[derive(PartialEq, Clone, Debug, XDROut, XDRIn)]
+pub enum DownloadRequestType {
+    UNKNOWN = 0,
+    HEIGHT = 1,
+    BLOCK = 2,
+}
+
+impl Default for DownloadRequestType {
+    fn default() -> Self {
+        DownloadRequestType::UNKNOWN
+    }
+}
+// Start union section
+
+#[derive(PartialEq, Clone, Debug, XDROut, XDRIn)]
+pub enum DownloadRequestPayload {
+    UNKNOWN(()),
+
+    HEIGHT(()),
+
+    BLOCK(u64),
+}
+
+impl Default for DownloadRequestPayload {
+    fn default() -> Self {
+        DownloadRequestPayload::UNKNOWN(())
+    }
+}
+
+#[derive(PartialEq, Clone, Debug, XDROut, XDRIn)]
+pub enum DownloadResponsePayload {
+    UNKNOWN(()),
+
+    HEIGHT(u64),
+
+    BLOCK(Block),
+}
+
+impl Default for DownloadResponsePayload {
+    fn default() -> Self {
+        DownloadResponsePayload::UNKNOWN(())
+    }
+}
+// End union section
+
+// Namspace end mazzaroth
+// Namspace start mazzaroth
+
+// Start typedef section
+
+// End typedef section
+
+// Start struct section
+
+#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Event {
     #[array(var = 256)]
     pub key: String,

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -63,6 +63,8 @@ pub struct BlockHeader {
 
     pub transactionHeight: u64,
 
+    pub consensusSequenceNumber: u64,
+
     pub txMerkleRoot: Hash,
 
     pub txReceiptRoot: Hash,

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -200,12 +200,12 @@ pub struct ContractMetadata {
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct DownloadRequest {
-    pub requestPayload: RequestPayload,
+    pub DownloadRequestPayload: DownloadRequestPayload,
 }
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct DownloadResponse {
-    pub ResponsePayload: ResponsePayload,
+    pub DownloadResponsePayload: DownloadResponsePayload,
 }
 
 // End struct section

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -61,6 +61,8 @@ pub struct BlockHeader {
 
     pub blockHeight: u64,
 
+    pub transactionHeight: u64,
+
     pub txMerkleRoot: Hash,
 
     pub txReceiptRoot: Hash,
@@ -200,12 +202,12 @@ pub struct ContractMetadata {
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct DownloadRequest {
-    pub DownloadRequestPayload: DownloadRequestPayload,
+    pub downloadRequestPayload: DownloadRequestPayload,
 }
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct DownloadResponse {
-    pub DownloadResponsePayload: DownloadResponsePayload,
+    pub downloadResponsePayload: DownloadResponsePayload,
 }
 
 // End struct section

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -530,7 +530,7 @@ var (
 
 // DownloadRequest generated struct
 type DownloadRequest struct {
-	RequestPayload RequestPayload
+	DownloadRequestPayload DownloadRequestPayload
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
@@ -553,7 +553,7 @@ var (
 
 // DownloadResponse generated struct
 type DownloadResponse struct {
-	ResponsePayload ResponsePayload
+	DownloadResponsePayload DownloadResponsePayload
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -108,6 +108,8 @@ type BlockHeader struct {
 
 	BlockHeight uint64
 
+	TransactionHeight uint64
+
 	TxMerkleRoot Hash
 
 	TxReceiptRoot Hash
@@ -642,7 +644,7 @@ var (
 type DownloadRequestPayload struct {
 	Type DownloadRequestType
 
-	Height *uint64
+	BlockNumber *uint64
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -663,7 +665,7 @@ func (u DownloadRequestPayload) ArmForSwitch(sw int32) (string, bool) {
 		return "", true
 
 	case DownloadRequestTypeBLOCK:
-		return "Height", true
+		return "BlockNumber", true
 	}
 	return "-", false
 }
@@ -684,31 +686,31 @@ func NewDownloadRequestPayload(aType DownloadRequestType, value interface{}) (re
 			err = fmt.Errorf("invalid value, must be [object]")
 			return
 		}
-		result.Height = &tv
+		result.BlockNumber = &tv
 
 	}
 	return
 }
 
-// MustHeight retrieves the Height value from the union,
+// MustBlockNumber retrieves the BlockNumber value from the union,
 // panicing if the value is not set.
-func (u DownloadRequestPayload) MustHeight() uint64 {
-	val, ok := u.GetHeight()
+func (u DownloadRequestPayload) MustBlockNumber() uint64 {
+	val, ok := u.GetBlockNumber()
 
 	if !ok {
-		panic("arm Height is not set")
+		panic("arm BlockNumber is not set")
 	}
 
 	return val
 }
 
-// GetHeight retrieves the Height value from the union,
+// GetBlockNumber retrieves the BlockNumber value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u DownloadRequestPayload) GetHeight() (result uint64, ok bool) {
+func (u DownloadRequestPayload) GetBlockNumber() (result uint64, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
-	if armName == "Height" {
-		result = *u.Height
+	if armName == "BlockNumber" {
+		result = *u.BlockNumber
 		ok = true
 	}
 

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -528,6 +528,351 @@ var (
 
 // Start struct section
 
+// DownloadRequest generated struct
+type DownloadRequest struct {
+	RequestPayload RequestPayload
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s DownloadRequest) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *DownloadRequest) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*DownloadRequest)(nil)
+	_ encoding.BinaryUnmarshaler = (*DownloadRequest)(nil)
+)
+
+// DownloadResponse generated struct
+type DownloadResponse struct {
+	ResponsePayload ResponsePayload
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s DownloadResponse) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *DownloadResponse) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*DownloadResponse)(nil)
+	_ encoding.BinaryUnmarshaler = (*DownloadResponse)(nil)
+)
+
+// End struct section
+
+// Start enum section
+
+// DownloadRequestType generated enum
+type DownloadRequestType int32
+
+const (
+
+	// DownloadRequestTypeUNKNOWN enum value 0
+	DownloadRequestTypeUNKNOWN DownloadRequestType = 0
+
+	// DownloadRequestTypeHEIGHT enum value 1
+	DownloadRequestTypeHEIGHT DownloadRequestType = 1
+
+	// DownloadRequestTypeBLOCK enum value 2
+	DownloadRequestTypeBLOCK DownloadRequestType = 2
+)
+
+// DownloadRequestTypeMap generated enum map
+var DownloadRequestTypeMap = map[int32]string{
+
+	0: "DownloadRequestTypeUNKNOWN",
+
+	1: "DownloadRequestTypeHEIGHT",
+
+	2: "DownloadRequestTypeBLOCK",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for DownloadRequestType
+func (s DownloadRequestType) ValidEnum(v int32) bool {
+	_, ok := DownloadRequestTypeMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (s DownloadRequestType) String() string {
+	name, _ := DownloadRequestTypeMap[int32(s)]
+	return name
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s DownloadRequestType) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *DownloadRequestType) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*DownloadRequestType)(nil)
+	_ encoding.BinaryUnmarshaler = (*DownloadRequestType)(nil)
+)
+
+// End enum section
+
+// Start union section
+
+// DownloadRequestPayload generated union
+type DownloadRequestPayload struct {
+	Type DownloadRequestType
+
+	Height *uint64
+}
+
+// SwitchFieldName returns the field name in which this union's
+// discriminant is stored
+func (u DownloadRequestPayload) SwitchFieldName() string {
+	return "Type"
+}
+
+// ArmForSwitch returns which field name should be used for storing
+// the value for an instance of DownloadRequestPayload
+func (u DownloadRequestPayload) ArmForSwitch(sw int32) (string, bool) {
+	switch DownloadRequestType(sw) {
+
+	case DownloadRequestTypeUNKNOWN:
+		return "", true
+
+	case DownloadRequestTypeHEIGHT:
+		return "", true
+
+	case DownloadRequestTypeBLOCK:
+		return "Height", true
+	}
+	return "-", false
+}
+
+// NewDownloadRequestPayload creates a new  DownloadRequestPayload.
+func NewDownloadRequestPayload(aType DownloadRequestType, value interface{}) (result DownloadRequestPayload, err error) {
+	result.Type = aType
+	switch aType {
+
+	case DownloadRequestTypeUNKNOWN:
+
+	case DownloadRequestTypeHEIGHT:
+
+	case DownloadRequestTypeBLOCK:
+
+		tv, ok := value.(uint64)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be [object]")
+			return
+		}
+		result.Height = &tv
+
+	}
+	return
+}
+
+// MustHeight retrieves the Height value from the union,
+// panicing if the value is not set.
+func (u DownloadRequestPayload) MustHeight() uint64 {
+	val, ok := u.GetHeight()
+
+	if !ok {
+		panic("arm Height is not set")
+	}
+
+	return val
+}
+
+// GetHeight retrieves the Height value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u DownloadRequestPayload) GetHeight() (result uint64, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "Height" {
+		result = *u.Height
+		ok = true
+	}
+
+	return
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (u DownloadRequestPayload) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, u)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (u *DownloadRequestPayload) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), u)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*DownloadRequestPayload)(nil)
+	_ encoding.BinaryUnmarshaler = (*DownloadRequestPayload)(nil)
+)
+
+// DownloadResponsePayload generated union
+type DownloadResponsePayload struct {
+	Type DownloadRequestType
+
+	Height *uint64
+
+	Block *Block
+}
+
+// SwitchFieldName returns the field name in which this union's
+// discriminant is stored
+func (u DownloadResponsePayload) SwitchFieldName() string {
+	return "Type"
+}
+
+// ArmForSwitch returns which field name should be used for storing
+// the value for an instance of DownloadResponsePayload
+func (u DownloadResponsePayload) ArmForSwitch(sw int32) (string, bool) {
+	switch DownloadRequestType(sw) {
+
+	case DownloadRequestTypeUNKNOWN:
+		return "", true
+
+	case DownloadRequestTypeHEIGHT:
+		return "Height", true
+
+	case DownloadRequestTypeBLOCK:
+		return "Block", true
+	}
+	return "-", false
+}
+
+// NewDownloadResponsePayload creates a new  DownloadResponsePayload.
+func NewDownloadResponsePayload(aType DownloadRequestType, value interface{}) (result DownloadResponsePayload, err error) {
+	result.Type = aType
+	switch aType {
+
+	case DownloadRequestTypeUNKNOWN:
+
+	case DownloadRequestTypeHEIGHT:
+
+		tv, ok := value.(uint64)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be [object]")
+			return
+		}
+		result.Height = &tv
+
+	case DownloadRequestTypeBLOCK:
+
+		tv, ok := value.(Block)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be [object]")
+			return
+		}
+		result.Block = &tv
+
+	}
+	return
+}
+
+// MustHeight retrieves the Height value from the union,
+// panicing if the value is not set.
+func (u DownloadResponsePayload) MustHeight() uint64 {
+	val, ok := u.GetHeight()
+
+	if !ok {
+		panic("arm Height is not set")
+	}
+
+	return val
+}
+
+// GetHeight retrieves the Height value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u DownloadResponsePayload) GetHeight() (result uint64, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "Height" {
+		result = *u.Height
+		ok = true
+	}
+
+	return
+}
+
+// MustBlock retrieves the Block value from the union,
+// panicing if the value is not set.
+func (u DownloadResponsePayload) MustBlock() Block {
+	val, ok := u.GetBlock()
+
+	if !ok {
+		panic("arm Block is not set")
+	}
+
+	return val
+}
+
+// GetBlock retrieves the Block value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u DownloadResponsePayload) GetBlock() (result Block, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "Block" {
+		result = *u.Block
+		ok = true
+	}
+
+	return
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (u DownloadResponsePayload) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, u)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (u *DownloadResponsePayload) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), u)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*DownloadResponsePayload)(nil)
+	_ encoding.BinaryUnmarshaler = (*DownloadResponsePayload)(nil)
+)
+
+// End union section
+
+// Namspace end mazzaroth
+// Namspace start mazzaroth
+
+// Start typedef section
+
+// End typedef section
+
+// Start struct section
+
 // Event generated struct
 type Event struct {
 	Key string `xdrmaxsize:"256"`

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -110,6 +110,8 @@ type BlockHeader struct {
 
 	TransactionHeight uint64
 
+	ConsensusSequenceNumber uint64
+
 	TxMerkleRoot Hash
 
 	TxReceiptRoot Hash


### PR DESCRIPTION
Download request and response objects added used for syncing with network.

Block header updated to store transaction height and consensus sequence number to allow nodes to easily resume execution after syncing from network.