### PR TITLE
feat(download): add a status to the download response

### DIFF
--- a/idl/download.x
+++ b/idl/download.x
@@ -26,8 +26,22 @@ namespace mazzaroth
 
     // Download Responses returned from requests
     struct DownloadResponse {
+        DownloadStatus downloadStatus;
         DownloadResponsePayload downloadResponsePayload;
     }
+
+    // Status of a download request.
+    enum DownloadStatus
+    {
+        // The status is either not known or not set.
+        UNKNOWN = 0,
+
+        // Download request was successfull.
+        SUCCESS = 1,
+
+        // Download request failed.
+        FAILURE = 2,
+    };
 
     union DownloadResponsePayload switch (DownloadRequestType Type)
     {

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -18,6 +18,7 @@ exports.ContractMetadata = ContractMetadata;
 exports.DownloadRequest = DownloadRequest;
 exports.DownloadResponse = DownloadResponse;
 exports.DownloadRequestType = DownloadRequestType;
+exports.DownloadStatus = DownloadStatus;
 exports.DownloadRequestPayload = DownloadRequestPayload;
 exports.DownloadResponsePayload = DownloadResponsePayload;
 exports.Event = Event;
@@ -234,7 +235,7 @@ function DownloadRequest() {
     return new _xdrJsSerialize2.default.Struct(["downloadRequestPayload"], [DownloadRequestPayload()]);
 }
 function DownloadResponse() {
-    return new _xdrJsSerialize2.default.Struct(["downloadResponsePayload"], [DownloadResponsePayload()]);
+    return new _xdrJsSerialize2.default.Struct(["downloadStatus", "downloadResponsePayload"], [DownloadStatus(), DownloadResponsePayload()]);
 }
 
 // End struct section
@@ -246,6 +247,15 @@ function DownloadRequestType() {
         0: "UNKNOWN",
         1: "HEIGHT",
         2: "BLOCK"
+
+    });
+}
+
+function DownloadStatus() {
+    return new _xdrJsSerialize2.default.Enum({
+        0: "UNKNOWN",
+        1: "SUCCESS",
+        2: "FAILURE"
 
     });
 }

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -209,6 +209,8 @@ pub struct DownloadRequest {
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct DownloadResponse {
+    pub downloadStatus: DownloadStatus,
+
     pub downloadResponsePayload: DownloadResponsePayload,
 }
 
@@ -224,6 +226,19 @@ pub enum DownloadRequestType {
 impl Default for DownloadRequestType {
     fn default() -> Self {
         DownloadRequestType::UNKNOWN
+    }
+}
+
+#[derive(PartialEq, Clone, Debug, XDROut, XDRIn)]
+pub enum DownloadStatus {
+    UNKNOWN = 0,
+    SUCCESS = 1,
+    FAILURE = 2,
+}
+
+impl Default for DownloadStatus {
+    fn default() -> Self {
+        DownloadStatus::UNKNOWN
     }
 }
 // Start union section

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -557,6 +557,8 @@ var (
 
 // DownloadResponse generated struct
 type DownloadResponse struct {
+	DownloadStatus DownloadStatus
+
 	DownloadResponsePayload DownloadResponsePayload
 }
 
@@ -636,6 +638,62 @@ func (s *DownloadRequestType) UnmarshalBinary(inp []byte) error {
 var (
 	_ encoding.BinaryMarshaler   = (*DownloadRequestType)(nil)
 	_ encoding.BinaryUnmarshaler = (*DownloadRequestType)(nil)
+)
+
+// DownloadStatus generated enum
+type DownloadStatus int32
+
+const (
+
+	// DownloadStatusUNKNOWN enum value 0
+	DownloadStatusUNKNOWN DownloadStatus = 0
+
+	// DownloadStatusSUCCESS enum value 1
+	DownloadStatusSUCCESS DownloadStatus = 1
+
+	// DownloadStatusFAILURE enum value 2
+	DownloadStatusFAILURE DownloadStatus = 2
+)
+
+// DownloadStatusMap generated enum map
+var DownloadStatusMap = map[int32]string{
+
+	0: "DownloadStatusUNKNOWN",
+
+	1: "DownloadStatusSUCCESS",
+
+	2: "DownloadStatusFAILURE",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for DownloadStatus
+func (s DownloadStatus) ValidEnum(v int32) bool {
+	_, ok := DownloadStatusMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (s DownloadStatus) String() string {
+	name, _ := DownloadStatusMap[int32(s)]
+	return name
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s DownloadStatus) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *DownloadStatus) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*DownloadStatus)(nil)
+	_ encoding.BinaryUnmarshaler = (*DownloadStatus)(nil)
 )
 
 // End enum section


### PR DESCRIPTION
Add a success or failure status to download response messages.