### PR TITLE
Execution plan updates

### DIFF
--- a/idl/plan.x
+++ b/idl/plan.x
@@ -12,8 +12,8 @@ namespace mazzaroth
     // The id of the channel for the transactions
     ID channelID;
 
-    // The list of calls to submit to the Mazzaroth node
-    Call calls<100>;      
+    // The list of actions to submit to the Mazzaroth node
+    Action actions<100>;
   };
 
 }

--- a/idl/plan.x
+++ b/idl/plan.x
@@ -9,9 +9,6 @@ namespace mazzaroth
     // The host ip of the Mazzaroth node to target
     string host<256>;
 
-    // The id of the channel for the transactions
-    ID channelID;
-
     // The list of actions to submit to the Mazzaroth node
     Action actions<100>;
   };

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -334,7 +334,7 @@ function Event() {
 
 // Start struct section
 function ExecutionPlan() {
-    return new _xdrJsSerialize2.default.Struct(["host", "channelID", "calls"], [new _xdrJsSerialize2.default.Str('', 256), ID(), new _xdrJsSerialize2.default.VarArray(100, Call)]);
+    return new _xdrJsSerialize2.default.Struct(["host", "channelID", "actions"], [new _xdrJsSerialize2.default.Str('', 256), ID(), new _xdrJsSerialize2.default.VarArray(100, Action)]);
 }
 
 // End struct section

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -334,7 +334,7 @@ function Event() {
 
 // Start struct section
 function ExecutionPlan() {
-    return new _xdrJsSerialize2.default.Struct(["host", "channelID", "actions"], [new _xdrJsSerialize2.default.Str('', 256), ID(), new _xdrJsSerialize2.default.VarArray(100, Action)]);
+    return new _xdrJsSerialize2.default.Struct(["host", "actions"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.VarArray(100, Action)]);
 }
 
 // End struct section

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -336,7 +336,7 @@ pub struct ExecutionPlan {
     pub channelID: ID,
 
     #[array(var = 100)]
-    pub calls: Vec<Call>,
+    pub actions: Vec<Action>,
 }
 
 // End struct section

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -333,8 +333,6 @@ pub struct ExecutionPlan {
     #[array(var = 256)]
     pub host: String,
 
-    pub channelID: ID,
-
     #[array(var = 100)]
     pub actions: Vec<Action>,
 }

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -1037,7 +1037,7 @@ type ExecutionPlan struct {
 
 	ChannelID ID
 
-	Calls []Call `xdrmaxsize:"100"`
+	Actions []Action `xdrmaxsize:"100"`
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -1035,8 +1035,6 @@ var (
 type ExecutionPlan struct {
 	Host string `xdrmaxsize:"256"`
 
-	ChannelID ID
-
 	Actions []Action `xdrmaxsize:"100"`
 }
 


### PR DESCRIPTION
We need the execution plan to be able to execute generic actions so that
we can use an update authorization request to login to xchng.