### PR TITLE
feat(subscribe): removing boolean filter type replaced with int

### DIFF
--- a/idl/subscribe.x
+++ b/idl/subscribe.x
@@ -21,7 +21,7 @@ namespace mazzaroth
     HASH32 = 2,
     HASH64 = 3,
     UHYPER = 4,
-    BOOL = 5,
+    INT = 5,
   };
 
   union ValueFilter switch (ValueFilterType Type) 
@@ -36,8 +36,8 @@ namespace mazzaroth
       Hash64 hash64Value;
     case UHYPER:
       unsigned hyper uhyperValue;
-    case BOOL:
-      boolean boolValue;
+    case INT:
+      int intValue;
   };
 
   struct ReceiptValueFilter 

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -613,7 +613,7 @@ function ValueFilterType() {
         2: "HASH32",
         3: "HASH64",
         4: "UHYPER",
-        5: "BOOL"
+        5: "INT"
 
     });
 }
@@ -666,8 +666,8 @@ function ValueFilter() {
             return new _xdrJsSerialize2.default.UHyper();
         },
 
-        "BOOL": () => {
-            return new _xdrJsSerialize2.default.Bool();
+        "INT": () => {
+            return new _xdrJsSerialize2.default.Int();
         }
 
     });

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -751,7 +751,7 @@ pub enum ValueFilterType {
     HASH32 = 2,
     HASH64 = 3,
     UHYPER = 4,
-    BOOL = 5,
+    INT = 5,
 }
 
 impl Default for ValueFilterType {
@@ -801,7 +801,7 @@ pub enum ValueFilter {
 
     UHYPER(u64),
 
-    BOOL(bool),
+    INT(i32),
 }
 
 impl Default for ValueFilter {

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -2662,8 +2662,8 @@ const (
 	// ValueFilterTypeUHYPER enum value 4
 	ValueFilterTypeUHYPER ValueFilterType = 4
 
-	// ValueFilterTypeBOOL enum value 5
-	ValueFilterTypeBOOL ValueFilterType = 5
+	// ValueFilterTypeINT enum value 5
+	ValueFilterTypeINT ValueFilterType = 5
 )
 
 // ValueFilterTypeMap generated enum map
@@ -2679,7 +2679,7 @@ var ValueFilterTypeMap = map[int32]string{
 
 	4: "ValueFilterTypeUHYPER",
 
-	5: "ValueFilterTypeBOOL",
+	5: "ValueFilterTypeINT",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
@@ -2851,7 +2851,7 @@ type ValueFilter struct {
 
 	UhyperValue *uint64
 
-	BoolValue *bool
+	IntValue *int32
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -2880,8 +2880,8 @@ func (u ValueFilter) ArmForSwitch(sw int32) (string, bool) {
 	case ValueFilterTypeUHYPER:
 		return "UhyperValue", true
 
-	case ValueFilterTypeBOOL:
-		return "BoolValue", true
+	case ValueFilterTypeINT:
+		return "IntValue", true
 	}
 	return "-", false
 }
@@ -2929,14 +2929,14 @@ func NewValueFilter(aType ValueFilterType, value interface{}) (result ValueFilte
 		}
 		result.UhyperValue = &tv
 
-	case ValueFilterTypeBOOL:
+	case ValueFilterTypeINT:
 
-		tv, ok := value.(bool)
+		tv, ok := value.(int32)
 		if !ok {
 			err = fmt.Errorf("invalid value, must be [object]")
 			return
 		}
-		result.BoolValue = &tv
+		result.IntValue = &tv
 
 	}
 	return
@@ -3042,25 +3042,25 @@ func (u ValueFilter) GetUhyperValue() (result uint64, ok bool) {
 	return
 }
 
-// MustBoolValue retrieves the BoolValue value from the union,
+// MustIntValue retrieves the IntValue value from the union,
 // panicing if the value is not set.
-func (u ValueFilter) MustBoolValue() bool {
-	val, ok := u.GetBoolValue()
+func (u ValueFilter) MustIntValue() int32 {
+	val, ok := u.GetIntValue()
 
 	if !ok {
-		panic("arm BoolValue is not set")
+		panic("arm IntValue is not set")
 	}
 
 	return val
 }
 
-// GetBoolValue retrieves the BoolValue value from the union,
+// GetIntValue retrieves the IntValue value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u ValueFilter) GetBoolValue() (result bool, ok bool) {
+func (u ValueFilter) GetIntValue() (result int32, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
-	if armName == "BoolValue" {
-		result = *u.BoolValue
+	if armName == "IntValue" {
+		result = *u.IntValue
 		ok = true
 	}
 


### PR DESCRIPTION
A boolean was being used to represent enums with only two values. This
was confusing in practice so it is being replaced with an integer type.