### PR TITLE
feat(download):  add download type for committed batches

### DIFF
--- a/idl/download.x
+++ b/idl/download.x
@@ -51,10 +51,16 @@ namespace mazzaroth
         case UNKNOWN:
             void;
         case HEIGHT:
-            unsigned hyper height; // Return ledger height
+            DownloadHeight downloadHeight;
         case BLOCK:
             Block block; // Return the requested block
         case BATCHES:
             void; // Missing batches are sent in new messages, not a response
+    }
+
+    // Download Height info including ledger block height and last processed sequence number
+    struct DownloadHeight {
+        unsigned hyper height; // Return ledger height
+        unsigned hyper seqNum; // Return latest consensus sequence number
     }
 }

--- a/idl/download.x
+++ b/idl/download.x
@@ -24,7 +24,12 @@ namespace mazzaroth
         case BLOCK:
             unsigned hyper blockNumber;
         case BATCHES:
-            unsigned hyper seqNum;
+            BatchesRequest batchesRequest;
+    }
+
+    struct BatchesRequest {
+        unsigned hyper seqNum;
+        string id; // Own id for targeting batches
     }
 
     // Download Responses returned from requests

--- a/idl/download.x
+++ b/idl/download.x
@@ -11,7 +11,8 @@ namespace mazzaroth
     enum DownloadRequestType {
         UNKNOWN = 0,
         HEIGHT = 1, // Request current block height of node
-        BLOCK = 2 // Request a specific block from the node
+        BLOCK = 2, // Request a specific block from the node
+        BATCHES = 3 // Request the missing batches after last sequence number
     };
 
     union DownloadRequestPayload switch (DownloadRequestType Type)
@@ -22,6 +23,8 @@ namespace mazzaroth
             void;
         case BLOCK:
             unsigned hyper blockNumber;
+        case BATCHES:
+            unsigned hyper seqNum;
     }
 
     // Download Responses returned from requests
@@ -36,7 +39,7 @@ namespace mazzaroth
         // The status is either not known or not set.
         UNKNOWN = 0,
 
-        // Download request was successfull.
+        // Download request was successful.
         SUCCESS = 1,
 
         // Download request failed.
@@ -48,8 +51,10 @@ namespace mazzaroth
         case UNKNOWN:
             void;
         case HEIGHT:
-            unsigned hyper height;
+            unsigned hyper height; // Return ledger height
         case BLOCK:
-            Block block;
+            Block block; // Return the requested block
+        case BATCHES:
+            void; // Missing batches are sent in new messages, not a response
     }
 }

--- a/idl/download.x
+++ b/idl/download.x
@@ -29,7 +29,10 @@ namespace mazzaroth
 
     struct BatchesRequest {
         unsigned hyper seqNum;
-        string id; // Own id for targeting batches
+        // Node details to target peer with batches
+        string id;
+        string ip;
+        unsigned hyper port;
     }
 
     // Download Responses returned from requests

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -21,6 +21,7 @@ exports.PermissioningType = PermissioningType;
 exports.Permissioning = Permissioning;
 exports.DownloadRequest = DownloadRequest;
 exports.DownloadResponse = DownloadResponse;
+exports.DownloadHeight = DownloadHeight;
 exports.DownloadRequestType = DownloadRequestType;
 exports.DownloadStatus = DownloadStatus;
 exports.DownloadRequestPayload = DownloadRequestPayload;
@@ -264,6 +265,9 @@ function DownloadRequest() {
 function DownloadResponse() {
     return new _xdrJsSerialize2.default.Struct(["downloadStatus", "downloadResponsePayload"], [DownloadStatus(), DownloadResponsePayload()]);
 }
+function DownloadHeight() {
+    return new _xdrJsSerialize2.default.Struct(["height", "seqNum"], [new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.UHyper()]);
+}
 
 // End struct section
 
@@ -323,7 +327,7 @@ function DownloadResponsePayload() {
         },
 
         "HEIGHT": () => {
-            return new _xdrJsSerialize2.default.UHyper();
+            return DownloadHeight();
         },
 
         "BLOCK": () => {

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -264,7 +264,7 @@ function DownloadRequest() {
     return new _xdrJsSerialize2.default.Struct(["downloadRequestPayload"], [DownloadRequestPayload()]);
 }
 function BatchesRequest() {
-    return new _xdrJsSerialize2.default.Struct(["seqNum", "id"], [new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.Str('', 0)]);
+    return new _xdrJsSerialize2.default.Struct(["seqNum", "id", "ip", "port"], [new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.Str('', 0), new _xdrJsSerialize2.default.Str('', 0), new _xdrJsSerialize2.default.UHyper()]);
 }
 function DownloadResponse() {
     return new _xdrJsSerialize2.default.Struct(["downloadStatus", "downloadResponsePayload"], [DownloadStatus(), DownloadResponsePayload()]);

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -20,6 +20,7 @@ exports.ConsensusConfigType = ConsensusConfigType;
 exports.PermissioningType = PermissioningType;
 exports.Permissioning = Permissioning;
 exports.DownloadRequest = DownloadRequest;
+exports.BatchesRequest = BatchesRequest;
 exports.DownloadResponse = DownloadResponse;
 exports.DownloadHeight = DownloadHeight;
 exports.DownloadRequestType = DownloadRequestType;
@@ -262,6 +263,9 @@ function Permissioning() {
 function DownloadRequest() {
     return new _xdrJsSerialize2.default.Struct(["downloadRequestPayload"], [DownloadRequestPayload()]);
 }
+function BatchesRequest() {
+    return new _xdrJsSerialize2.default.Struct(["seqNum", "id"], [new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.Str('', 0)]);
+}
 function DownloadResponse() {
     return new _xdrJsSerialize2.default.Struct(["downloadStatus", "downloadResponsePayload"], [DownloadStatus(), DownloadResponsePayload()]);
 }
@@ -313,7 +317,7 @@ function DownloadRequestPayload() {
         },
 
         "BATCHES": () => {
-            return new _xdrJsSerialize2.default.UHyper();
+            return BatchesRequest();
         }
 
     });

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -273,7 +273,8 @@ function DownloadRequestType() {
     return new _xdrJsSerialize2.default.Enum({
         0: "UNKNOWN",
         1: "HEIGHT",
-        2: "BLOCK"
+        2: "BLOCK",
+        3: "BATCHES"
 
     });
 }
@@ -305,6 +306,10 @@ function DownloadRequestPayload() {
 
         "BLOCK": () => {
             return new _xdrJsSerialize2.default.UHyper();
+        },
+
+        "BATCHES": () => {
+            return new _xdrJsSerialize2.default.UHyper();
         }
 
     });
@@ -323,6 +328,10 @@ function DownloadResponsePayload() {
 
         "BLOCK": () => {
             return Block();
+        },
+
+        "BATCHES": () => {
+            return new _xdrJsSerialize2.default.Void();
         }
 
     });

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -248,6 +248,10 @@ pub struct BatchesRequest {
     pub seqNum: u64,
 
     pub id: String,
+
+    pub ip: String,
+
+    pub port: u64,
 }
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -244,6 +244,13 @@ pub struct DownloadRequest {
 }
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
+pub struct BatchesRequest {
+    pub seqNum: u64,
+
+    pub id: String,
+}
+
+#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct DownloadResponse {
     pub downloadStatus: DownloadStatus,
 
@@ -295,7 +302,7 @@ pub enum DownloadRequestPayload {
 
     BLOCK(u64),
 
-    BATCHES(u64),
+    BATCHES(BatchesRequest),
 }
 
 impl Default for DownloadRequestPayload {

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -250,6 +250,13 @@ pub struct DownloadResponse {
     pub downloadResponsePayload: DownloadResponsePayload,
 }
 
+#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
+pub struct DownloadHeight {
+    pub height: u64,
+
+    pub seqNum: u64,
+}
+
 // End struct section
 
 #[derive(PartialEq, Clone, Debug, XDROut, XDRIn)]
@@ -301,7 +308,7 @@ impl Default for DownloadRequestPayload {
 pub enum DownloadResponsePayload {
     UNKNOWN(()),
 
-    HEIGHT(u64),
+    HEIGHT(DownloadHeight),
 
     BLOCK(Block),
 

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -257,6 +257,7 @@ pub enum DownloadRequestType {
     UNKNOWN = 0,
     HEIGHT = 1,
     BLOCK = 2,
+    BATCHES = 3,
 }
 
 impl Default for DownloadRequestType {
@@ -286,6 +287,8 @@ pub enum DownloadRequestPayload {
     HEIGHT(()),
 
     BLOCK(u64),
+
+    BATCHES(u64),
 }
 
 impl Default for DownloadRequestPayload {
@@ -301,6 +304,8 @@ pub enum DownloadResponsePayload {
     HEIGHT(u64),
 
     BLOCK(Block),
+
+    BATCHES(()),
 }
 
 impl Default for DownloadResponsePayload {

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -705,6 +705,31 @@ var (
 	_ encoding.BinaryUnmarshaler = (*DownloadResponse)(nil)
 )
 
+// DownloadHeight generated struct
+type DownloadHeight struct {
+	Height uint64
+
+	SeqNum uint64
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s DownloadHeight) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *DownloadHeight) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*DownloadHeight)(nil)
+	_ encoding.BinaryUnmarshaler = (*DownloadHeight)(nil)
+)
+
 // End struct section
 
 // Start enum section
@@ -968,7 +993,7 @@ var (
 type DownloadResponsePayload struct {
 	Type DownloadRequestType
 
-	Height *uint64
+	DownloadHeight *DownloadHeight
 
 	Block *Block
 }
@@ -988,7 +1013,7 @@ func (u DownloadResponsePayload) ArmForSwitch(sw int32) (string, bool) {
 		return "", true
 
 	case DownloadRequestTypeHEIGHT:
-		return "Height", true
+		return "DownloadHeight", true
 
 	case DownloadRequestTypeBLOCK:
 		return "Block", true
@@ -1008,12 +1033,12 @@ func NewDownloadResponsePayload(aType DownloadRequestType, value interface{}) (r
 
 	case DownloadRequestTypeHEIGHT:
 
-		tv, ok := value.(uint64)
+		tv, ok := value.(DownloadHeight)
 		if !ok {
 			err = fmt.Errorf("invalid value, must be [object]")
 			return
 		}
-		result.Height = &tv
+		result.DownloadHeight = &tv
 
 	case DownloadRequestTypeBLOCK:
 
@@ -1030,25 +1055,25 @@ func NewDownloadResponsePayload(aType DownloadRequestType, value interface{}) (r
 	return
 }
 
-// MustHeight retrieves the Height value from the union,
+// MustDownloadHeight retrieves the DownloadHeight value from the union,
 // panicing if the value is not set.
-func (u DownloadResponsePayload) MustHeight() uint64 {
-	val, ok := u.GetHeight()
+func (u DownloadResponsePayload) MustDownloadHeight() DownloadHeight {
+	val, ok := u.GetDownloadHeight()
 
 	if !ok {
-		panic("arm Height is not set")
+		panic("arm DownloadHeight is not set")
 	}
 
 	return val
 }
 
-// GetHeight retrieves the Height value from the union,
+// GetDownloadHeight retrieves the DownloadHeight value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u DownloadResponsePayload) GetHeight() (result uint64, ok bool) {
+func (u DownloadResponsePayload) GetDownloadHeight() (result DownloadHeight, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
-	if armName == "Height" {
-		result = *u.Height
+	if armName == "DownloadHeight" {
+		result = *u.DownloadHeight
 		ok = true
 	}
 

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -685,6 +685,10 @@ type BatchesRequest struct {
 	SeqNum uint64
 
 	Id string
+
+	Ip string
+
+	Port uint64
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -680,6 +680,31 @@ var (
 	_ encoding.BinaryUnmarshaler = (*DownloadRequest)(nil)
 )
 
+// BatchesRequest generated struct
+type BatchesRequest struct {
+	SeqNum uint64
+
+	Id string
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s BatchesRequest) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *BatchesRequest) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*BatchesRequest)(nil)
+	_ encoding.BinaryUnmarshaler = (*BatchesRequest)(nil)
+)
+
 // DownloadResponse generated struct
 type DownloadResponse struct {
 	DownloadStatus DownloadStatus
@@ -861,7 +886,7 @@ type DownloadRequestPayload struct {
 
 	BlockNumber *uint64
 
-	SeqNum *uint64
+	BatchesRequest *BatchesRequest
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -885,7 +910,7 @@ func (u DownloadRequestPayload) ArmForSwitch(sw int32) (string, bool) {
 		return "BlockNumber", true
 
 	case DownloadRequestTypeBATCHES:
-		return "SeqNum", true
+		return "BatchesRequest", true
 	}
 	return "-", false
 }
@@ -910,12 +935,12 @@ func NewDownloadRequestPayload(aType DownloadRequestType, value interface{}) (re
 
 	case DownloadRequestTypeBATCHES:
 
-		tv, ok := value.(uint64)
+		tv, ok := value.(BatchesRequest)
 		if !ok {
 			err = fmt.Errorf("invalid value, must be [object]")
 			return
 		}
-		result.SeqNum = &tv
+		result.BatchesRequest = &tv
 
 	}
 	return
@@ -946,25 +971,25 @@ func (u DownloadRequestPayload) GetBlockNumber() (result uint64, ok bool) {
 	return
 }
 
-// MustSeqNum retrieves the SeqNum value from the union,
+// MustBatchesRequest retrieves the BatchesRequest value from the union,
 // panicing if the value is not set.
-func (u DownloadRequestPayload) MustSeqNum() uint64 {
-	val, ok := u.GetSeqNum()
+func (u DownloadRequestPayload) MustBatchesRequest() BatchesRequest {
+	val, ok := u.GetBatchesRequest()
 
 	if !ok {
-		panic("arm SeqNum is not set")
+		panic("arm BatchesRequest is not set")
 	}
 
 	return val
 }
 
-// GetSeqNum retrieves the SeqNum value from the union,
+// GetBatchesRequest retrieves the BatchesRequest value from the union,
 // returning ok if the union's switch indicated the value is valid.
-func (u DownloadRequestPayload) GetSeqNum() (result uint64, ok bool) {
+func (u DownloadRequestPayload) GetBatchesRequest() (result BatchesRequest, ok bool) {
 	armName, _ := u.ArmForSwitch(int32(u.Type))
 
-	if armName == "SeqNum" {
-		result = *u.SeqNum
+	if armName == "BatchesRequest" {
+		result = *u.BatchesRequest
 		ok = true
 	}
 

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -722,6 +722,9 @@ const (
 
 	// DownloadRequestTypeBLOCK enum value 2
 	DownloadRequestTypeBLOCK DownloadRequestType = 2
+
+	// DownloadRequestTypeBATCHES enum value 3
+	DownloadRequestTypeBATCHES DownloadRequestType = 3
 )
 
 // DownloadRequestTypeMap generated enum map
@@ -732,6 +735,8 @@ var DownloadRequestTypeMap = map[int32]string{
 	1: "DownloadRequestTypeHEIGHT",
 
 	2: "DownloadRequestTypeBLOCK",
+
+	3: "DownloadRequestTypeBATCHES",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
@@ -830,6 +835,8 @@ type DownloadRequestPayload struct {
 	Type DownloadRequestType
 
 	BlockNumber *uint64
+
+	SeqNum *uint64
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -851,6 +858,9 @@ func (u DownloadRequestPayload) ArmForSwitch(sw int32) (string, bool) {
 
 	case DownloadRequestTypeBLOCK:
 		return "BlockNumber", true
+
+	case DownloadRequestTypeBATCHES:
+		return "SeqNum", true
 	}
 	return "-", false
 }
@@ -872,6 +882,15 @@ func NewDownloadRequestPayload(aType DownloadRequestType, value interface{}) (re
 			return
 		}
 		result.BlockNumber = &tv
+
+	case DownloadRequestTypeBATCHES:
+
+		tv, ok := value.(uint64)
+		if !ok {
+			err = fmt.Errorf("invalid value, must be [object]")
+			return
+		}
+		result.SeqNum = &tv
 
 	}
 	return
@@ -896,6 +915,31 @@ func (u DownloadRequestPayload) GetBlockNumber() (result uint64, ok bool) {
 
 	if armName == "BlockNumber" {
 		result = *u.BlockNumber
+		ok = true
+	}
+
+	return
+}
+
+// MustSeqNum retrieves the SeqNum value from the union,
+// panicing if the value is not set.
+func (u DownloadRequestPayload) MustSeqNum() uint64 {
+	val, ok := u.GetSeqNum()
+
+	if !ok {
+		panic("arm SeqNum is not set")
+	}
+
+	return val
+}
+
+// GetSeqNum retrieves the SeqNum value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u DownloadRequestPayload) GetSeqNum() (result uint64, ok bool) {
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "SeqNum" {
+		result = *u.SeqNum
 		ok = true
 	}
 
@@ -948,6 +992,9 @@ func (u DownloadResponsePayload) ArmForSwitch(sw int32) (string, bool) {
 
 	case DownloadRequestTypeBLOCK:
 		return "Block", true
+
+	case DownloadRequestTypeBATCHES:
+		return "", true
 	}
 	return "-", false
 }
@@ -976,6 +1023,8 @@ func NewDownloadResponsePayload(aType DownloadRequestType, value interface{}) (r
 			return
 		}
 		result.Block = &tv
+
+	case DownloadRequestTypeBATCHES:
 
 	}
 	return


### PR DESCRIPTION
- Add download request type to request committed batches from a given sequence number
- They are not returned in the download response, but in separate requests
- Added sequence number to download height