### PR TITLE
[#BCNDEV226] - adding Marshaler/Unmarshaler implementation to xdr bytes types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/kochavalabs/mazzaroth-xdr
 
 go 1.14
 
-require github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a
+require (
+	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/xdr/common.go
+++ b/xdr/common.go
@@ -2,9 +2,10 @@ package xdr
 
 import (
 	"crypto"
-	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 )
 
@@ -53,8 +54,8 @@ func IDFromPublicKey(pk crypto.PublicKey) (ID, error) {
 }
 
 // MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
-func (id *ID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(id[:]))
+func (id ID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hex.EncodeToString(id[:]))
 }
 
 // UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
@@ -63,20 +64,20 @@ func (id *ID) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	bb, err := base64.StdEncoding.DecodeString(s)
+	bb, err := hex.DecodeString(s)
 	if err != nil {
 		return err
 	}
 	if len(bb) != len(id) {
-		return &json.MarshalerError{Type: reflect.TypeOf(id), Err: errors.New("length of decoded string incorrect")}
+		return &json.MarshalerError{Type: reflect.TypeOf(id), Err: fmt.Errorf("length of decoded string incorrect: %d, should be %d", len(bb), len(id))}
 	}
-    copy(id[:], bb)
+	copy(id[:], bb)
 	return nil
 }
 
 // MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
-func (sig *Signature) MarshalJSON() ([]byte, error) {
-	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(sig[:]))
+func (sig Signature) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hex.EncodeToString(sig[:]))
 }
 
 // UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
@@ -85,20 +86,20 @@ func (sig *Signature) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	bb, err := base64.StdEncoding.DecodeString(s)
+	bb, err := hex.DecodeString(s)
 	if err != nil {
 		return err
 	}
 	if len(bb) != len(sig) {
-		return &json.MarshalerError{Type: reflect.TypeOf(sig), Err: errors.New("length of decoded string incorrect")}
+		return &json.MarshalerError{Type: reflect.TypeOf(sig), Err: fmt.Errorf("length of decoded string incorrect: %d, should be %d", len(bb), len(sig))}
 	}
-    copy(sig[:], bb)
+	copy(sig[:], bb)
 	return nil
 }
 
 // MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
-func (h *Hash) MarshalJSON() ([]byte, error) {
-	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(h[:]))
+func (h Hash) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hex.EncodeToString(h[:]))
 }
 
 // UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
@@ -107,20 +108,20 @@ func (h *Hash) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	bb, err := base64.StdEncoding.DecodeString(s)
+	bb, err := hex.DecodeString(s)
 	if err != nil {
 		return err
 	}
 	if len(bb) != len(h) {
-		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: errors.New("length of decoded string incorrect")}
+		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: fmt.Errorf("length of decoded string incorrect: %d, should be %d", len(bb), len(h))}
 	}
 	copy(h[:], bb)
 	return nil
 }
 
 // MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
-func (h *Hash32) MarshalJSON() ([]byte, error) {
-	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(h[:]))
+func (h Hash32) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hex.EncodeToString(h[:]))
 }
 
 // UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
@@ -129,20 +130,20 @@ func (h *Hash32) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	bb, err := base64.StdEncoding.DecodeString(s)
+	bb, err := hex.DecodeString(s)
 	if err != nil {
 		return err
 	}
 	if len(bb) != len(h) {
-		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: errors.New("length of decoded string incorrect")}
+		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: fmt.Errorf("length of decoded string incorrect: %d, should be %d", len(bb), len(h))}
 	}
 	copy(h[:], bb)
 	return nil
 }
 
 // MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
-func (h *Hash64) MarshalJSON() ([]byte, error) {
-	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(h[:]))
+func (h Hash64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hex.EncodeToString(h[:]))
 }
 
 // UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
@@ -151,12 +152,12 @@ func (h *Hash64) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	bb, err := base64.StdEncoding.DecodeString(s)
+	bb, err := hex.DecodeString(s)
 	if err != nil {
 		return err
 	}
 	if len(bb) != len(h) {
-		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: errors.New("length of decoded string incorrect")}
+		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: fmt.Errorf("length of decoded string incorrect: %d, should be %d", len(bb), len(h))}
 	}
 	copy(h[:], bb)
 	return nil

--- a/xdr/common.go
+++ b/xdr/common.go
@@ -53,12 +53,12 @@ func IDFromPublicKey(pk crypto.PublicKey) (ID, error) {
 	return IDFromSlice(bbytes)
 }
 
-// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// MarshalJSON : when marshaling to JSON we want ID to be represented as a hex-encoded string, not as an array of uint8
 func (id ID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(id[:]))
 }
 
-// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a hex-encoded string, not as an array of uint8
 func (id *ID) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -75,12 +75,12 @@ func (id *ID) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// MarshalJSON : when marshaling to JSON we want signature to be represented as a hex-encoded string, not as an array of uint8
 func (sig Signature) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(sig[:]))
 }
 
-// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// UnmarshalJSON : when marshaling to JSON we want Signature to be represented as a hex-encoded string, not as an array of uint8
 func (sig *Signature) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -97,12 +97,12 @@ func (sig *Signature) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// MarshalJSON : when marshaling to JSON we want Hash to be represented as a hex-encoded string, not as an array of uint8
 func (h Hash) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(h[:]))
 }
 
-// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// UnmarshalJSON : when marshaling to JSON we want Hash to be represented as a hex-encoded string, not as an array of uint8
 func (h *Hash) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -119,12 +119,12 @@ func (h *Hash) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// MarshalJSON : when marshaling to JSON we want Hash32 to be represented as a hex-encoded string, not as an array of uint8
 func (h Hash32) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(h[:]))
 }
 
-// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// UnmarshalJSON : when marshaling to JSON we want Hash32 to be represented as a hex-encoded string, not as an array of uint8
 func (h *Hash32) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -141,12 +141,12 @@ func (h *Hash32) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// MarshalJSON : when marshaling to JSON we want Hash64 to be represented as a hex-encoded string, not as an array of uint8
 func (h Hash64) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(h[:]))
 }
 
-// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+// UnmarshalJSON : when marshaling to JSON we want Hash64 to be represented as a hex-encoded string, not as an array of uint8
 func (h *Hash64) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {

--- a/xdr/common.go
+++ b/xdr/common.go
@@ -2,7 +2,10 @@ package xdr
 
 import (
 	"crypto"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"reflect"
 )
 
 // fromSlice32 converts a byte slice to a [32]byte
@@ -25,8 +28,8 @@ func fromSlice64(slice []byte) ([64]byte, error) {
 	return array, nil
 }
 
-// IdFromSlice gets an Id from a byte slice.
-func IdFromSlice(slice []byte) (ID, error) {
+// IDFromSlice gets an Id from a byte slice.
+func IDFromSlice(slice []byte) (ID, error) {
 	return fromSlice32(slice)
 }
 
@@ -40,11 +43,121 @@ func HashFromSlice(slice []byte) (Hash, error) {
 	return fromSlice32(slice)
 }
 
-// IdFromPublicKey : from generic crypto.PublicKey interface{} we try to extract an ID
-func IdFromPublicKey(pk crypto.PublicKey) (ID, error) {
+// IDFromPublicKey : from generic crypto.PublicKey interface{} we try to extract an ID
+func IDFromPublicKey(pk crypto.PublicKey) (ID, error) {
 	bbytes, ok := pk.([]byte)
 	if ok == false {
 		return ID{}, errors.New("public key not a slice of bytes")
 	}
-	return IdFromSlice(bbytes)
+	return IDFromSlice(bbytes)
+}
+
+// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (id *ID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(id[:]))
+}
+
+// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (id *ID) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	bb, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	if len(bb) != len(id) {
+		return &json.MarshalerError{Type: reflect.TypeOf(id), Err: errors.New("length of decoded string incorrect")}
+	}
+    copy(id[:], bb)
+	return nil
+}
+
+// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (sig *Signature) MarshalJSON() ([]byte, error) {
+	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(sig[:]))
+}
+
+// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (sig *Signature) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	bb, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	if len(bb) != len(sig) {
+		return &json.MarshalerError{Type: reflect.TypeOf(sig), Err: errors.New("length of decoded string incorrect")}
+	}
+    copy(sig[:], bb)
+	return nil
+}
+
+// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (h *Hash) MarshalJSON() ([]byte, error) {
+	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(h[:]))
+}
+
+// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (h *Hash) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	bb, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	if len(bb) != len(h) {
+		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: errors.New("length of decoded string incorrect")}
+	}
+	copy(h[:], bb)
+	return nil
+}
+
+// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (h *Hash32) MarshalJSON() ([]byte, error) {
+	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(h[:]))
+}
+
+// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (h *Hash32) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	bb, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	if len(bb) != len(h) {
+		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: errors.New("length of decoded string incorrect")}
+	}
+	copy(h[:], bb)
+	return nil
+}
+
+// MarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (h *Hash64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(base64.StdEncoding.WithPadding(base64.StdPadding).EncodeToString(h[:]))
+}
+
+// UnmarshalJSON : when marshaling to JSON we want ID to be represented as a base64-encoded string, not as an array of uint8
+func (h *Hash64) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	bb, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	if len(bb) != len(h) {
+		return &json.MarshalerError{Type: reflect.TypeOf(h), Err: errors.New("length of decoded string incorrect")}
+	}
+	copy(h[:], bb)
+	return nil
 }

--- a/xdr/common_test.go
+++ b/xdr/common_test.go
@@ -1,0 +1,36 @@
+package xdr
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_IDMarshal(t *testing.T) {
+	var id ID
+	rawbytes := bytes.Repeat([]byte{'a'}, 32)
+	copy(id[:], rawbytes)
+	b, err := id.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, []byte(`"YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="`), b, `$ echo "%v" | base64 -w0 # should look like %v`, string(rawbytes), string(b))
+}
+
+func Test_SignatureMarshal(t *testing.T) {
+	var sig Signature
+	rawbytes := bytes.Repeat([]byte{'a'}, 64)
+	copy(sig[:], rawbytes)
+	b, err := sig.MarshalJSON()
+	require.NoError(t, err)
+	// watch out for padding, here we have two chars of padding
+	require.Equal(t, []byte(`"YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ=="`), b, `$ echo "%v" | base64 -w0 # should look like %v`, string(rawbytes), string(b))
+}
+
+func Test_IDUnmarshal(t *testing.T) {
+	st := `"YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="`
+	var id ID
+	err := id.UnmarshalJSON([]byte(st))
+	require.NoError(t, err)
+	expected := bytes.Repeat([]byte{'a'}, 32)
+	require.Equal(t, expected, id[:], `$ echo "%v" | base64 -d #should look like %v`, st, string(expected))
+}

--- a/xdr/common_test.go
+++ b/xdr/common_test.go
@@ -2,6 +2,9 @@ package xdr
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,26 +14,103 @@ func Test_IDMarshal(t *testing.T) {
 	var id ID
 	rawbytes := bytes.Repeat([]byte{'a'}, 32)
 	copy(id[:], rawbytes)
-	b, err := id.MarshalJSON()
+	b, err := json.Marshal(id)
 	require.NoError(t, err)
-	require.Equal(t, []byte(`"YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="`), b, `$ echo "%v" | base64 -w0 # should look like %v`, string(rawbytes), string(b))
+	expected := []byte{'"'}
+	expected = append(expected, bytes.Repeat([]byte{'6', '1'}, 32)...)
+	expected = append(expected, '"')
+	require.Equal(t, expected, b, `$ echo -n "%v" | xxd -p -c 256 # should look something like %v`, string(rawbytes), string(b))
 }
 
 func Test_SignatureMarshal(t *testing.T) {
 	var sig Signature
 	rawbytes := bytes.Repeat([]byte{'a'}, 64)
 	copy(sig[:], rawbytes)
-	b, err := sig.MarshalJSON()
+	b, err := json.Marshal(sig)
 	require.NoError(t, err)
-	// watch out for padding, here we have two chars of padding
-	require.Equal(t, []byte(`"YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ=="`), b, `$ echo "%v" | base64 -w0 # should look like %v`, string(rawbytes), string(b))
+	expected := []byte{'"'}
+	expected = append(expected, bytes.Repeat([]byte{'6', '1'}, 64)...)
+	expected = append(expected, '"')
+	require.Equal(t, expected, b, `$ echo -n "%v" | xxd -p -c 256 # should look like %v`, string(rawbytes), string(b))
+}
+
+func Test_HashMarshal(t *testing.T) {
+	var hash Hash
+	rawbytes := bytes.Repeat([]byte{'a'}, 32)
+	copy(hash[:], rawbytes)
+	b, err := json.Marshal(hash)
+	require.NoError(t, err)
+	expected := []byte{'"'}
+	expected = append(expected, bytes.Repeat([]byte{'6', '1'}, 32)...)
+	expected = append(expected, '"')
+	require.Equal(t, expected, b, `$ echo -n "%v" | xxd -p -c 256 # should look something like %v`, string(rawbytes), string(b))
+}
+
+func Test_Hash32Marshal(t *testing.T) {
+	var hash Hash32
+	rawbytes := bytes.Repeat([]byte{'a'}, 32)
+	copy(hash[:], rawbytes)
+	b, err := json.Marshal(hash)
+	require.NoError(t, err)
+	expected := []byte{'"'}
+	expected = append(expected, bytes.Repeat([]byte{'6', '1'}, 32)...)
+	expected = append(expected, '"')
+	require.Equal(t, expected, b, `$ echo -n "%v" | xxd -p -c 256 # should look something like %v`, string(rawbytes), string(b))
+}
+
+func Test_Hash64Marshal(t *testing.T) {
+	var hash Hash64
+	rawbytes := bytes.Repeat([]byte{'a'}, 64)
+	copy(hash[:], rawbytes)
+	b, err := json.Marshal(hash)
+	require.NoError(t, err)
+	expected := []byte{'"'}
+	expected = append(expected, bytes.Repeat([]byte{'6', '1'}, 64)...)
+	expected = append(expected, '"')
+	require.Equal(t, expected, b, `$ echo -n "%v" | xxd -p -c 256 # should look something like %v`, string(rawbytes), string(b))
 }
 
 func Test_IDUnmarshal(t *testing.T) {
-	st := `"YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="`
+	st := fmt.Sprintf(`"%s"`, strings.Repeat("61", 32))
 	var id ID
-	err := id.UnmarshalJSON([]byte(st))
+	err := json.Unmarshal([]byte(st), &id)
 	require.NoError(t, err)
 	expected := bytes.Repeat([]byte{'a'}, 32)
-	require.Equal(t, expected, id[:], `$ echo "%v" | base64 -d #should look like %v`, st, string(expected))
+	require.Equal(t, expected, id[:], `$ echo "%v" | xxd -r  -p -c 256 #should look like %v`, st, string(expected))
+}
+
+func Test_SignatureUnmarshal(t *testing.T) {
+	st := fmt.Sprintf(`"%s"`, strings.Repeat("61", 64))
+	var sig Signature
+	err := json.Unmarshal([]byte(st), &sig)
+	require.NoError(t, err)
+	expected := bytes.Repeat([]byte{'a'}, 64)
+	require.Equal(t, expected, sig[:], `$ echo "%v" | xxd -r  -p -c 256 #should look like %v`, st, string(expected))
+}
+
+func Test_HashUnmarshal(t *testing.T) {
+	st := fmt.Sprintf(`"%s"`, strings.Repeat("61", 32))
+	var hash Hash
+	err := json.Unmarshal([]byte(st), &hash)
+	require.NoError(t, err)
+	expected := bytes.Repeat([]byte{'a'}, 32)
+	require.Equal(t, expected, hash[:], `$ echo "%v" | xxd -r  -p -c 256 #should look like %v`, st, string(expected))
+}
+
+func Test_Hash32Unmarshal(t *testing.T) {
+	st := fmt.Sprintf(`"%s"`, strings.Repeat("61", 32))
+	var hash Hash32
+	err := json.Unmarshal([]byte(st), &hash)
+	require.NoError(t, err)
+	expected := bytes.Repeat([]byte{'a'}, 32)
+	require.Equal(t, expected, hash[:], `$ echo "%v" | xxd -r  -p -c 256 #should look like %v`, st, string(expected))
+}
+
+func Test_Hash64Unmarshal(t *testing.T) {
+	st := fmt.Sprintf(`"%s"`, strings.Repeat("61", 64))
+	var hash Hash64
+	err := json.Unmarshal([]byte(st), &hash)
+	require.NoError(t, err)
+	expected := bytes.Repeat([]byte{'a'}, 64)
+	require.Equal(t, expected, hash[:], `$ echo "%v" | xxd -r  -p -c 256 #should look like %v`, st, string(expected))
 }


### PR DESCRIPTION
## Description 
Implementing MarshalJSON and UnmarshalJSON for types
ID
Signature
Hash
Hash32
Hash64

## Related issue
https://app.asana.com/0/1200051730732841/1200162940662696/f

## Motivation & Context
In xdr we define ID, Signature, Hash, Hash32 and Hash64 types that are translated into [32]byte or [64]byte types in Go.
If we leave the Go Json package marshal and unmarshal values of these types, they are translated into arrays of uint8.
We don't want this, so we need to implement the proper interfaces to encode/decode the arrays of bytes into base64 strings.

