### PR TITLE
feat(config): removed channelID and version from config, moved hash to contract object

### DIFF
--- a/idl/config.x
+++ b/idl/config.x
@@ -6,12 +6,6 @@ namespace mazzaroth
   // accessible through host contract host functions
   struct ChannelConfig
   {
-    // Unique channel id which cannot be changed
-    ID channelID;
-    // Hash of the contract bytes
-    Hash contractHash;
-    // Version number of the contract, specified by owner
-    string version<200>;
     // Public Key ID of the channel owner. Only owner can change this to transfer ownership of channel
     ID owner;
     // Human readable channel name

--- a/idl/transaction.x
+++ b/idl/transaction.x
@@ -38,10 +38,13 @@ namespace mazzaroth
   struct Contract
   {
     // Contract binary bytes.
-    opaque contract<>;
+    opaque contractBytes<>;
+
+    // Sha3 256 Hash of the contract bytes, verified on execution
+    Hash contractHash;
 
     // Version number of the contract, specified by owner
-    string version;
+    string version<100>;
   }
 
   enum PermissionAction

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -198,7 +198,7 @@ function StatusInfo() {
 
 // Start struct section
 function ChannelConfig() {
-    return new _xdrJsSerialize2.default.Struct(["channelID", "contractHash", "version", "owner", "channelName", "admins"], [ID(), Hash(), new _xdrJsSerialize2.default.Str('', 200), ID(), new _xdrJsSerialize2.default.Str('', 200), new _xdrJsSerialize2.default.VarArray(200, ID)]);
+    return new _xdrJsSerialize2.default.Struct(["owner", "channelName", "admins"], [ID(), new _xdrJsSerialize2.default.Str('', 200), new _xdrJsSerialize2.default.VarArray(200, ID)]);
 }
 function GovernanceConfig() {
     return new _xdrJsSerialize2.default.Struct(["maxBlockSize", "consensus", "permissioning"], [new _xdrJsSerialize2.default.UHyper(), ConsensusConfigType(), Permissioning()]);
@@ -747,7 +747,7 @@ function Call() {
     return new _xdrJsSerialize2.default.Struct(["function", "parameters"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.VarArray(2147483647, Parameter)]);
 }
 function Contract() {
-    return new _xdrJsSerialize2.default.Struct(["contract", "version"], [new _xdrJsSerialize2.default.VarOpaque(2147483647), new _xdrJsSerialize2.default.Str('', 0)]);
+    return new _xdrJsSerialize2.default.Struct(["contractBytes", "contractHash", "version"], [new _xdrJsSerialize2.default.VarOpaque(2147483647), Hash(), new _xdrJsSerialize2.default.Str('', 100)]);
 }
 function Permission() {
     return new _xdrJsSerialize2.default.Struct(["key", "action"], [ID(), PermissionAction()]);

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -151,13 +151,6 @@ pub struct StatusInfo {
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct ChannelConfig {
-    pub channelID: ID,
-
-    pub contractHash: Hash,
-
-    #[array(var = 200)]
-    pub version: String,
-
     pub owner: ID,
 
     #[array(var = 200)]
@@ -890,8 +883,11 @@ pub struct Call {
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Contract {
     #[array(var = 2147483647)]
-    pub contract: Vec<u8>,
+    pub contractBytes: Vec<u8>,
 
+    pub contractHash: Hash,
+
+    #[array(var = 100)]
     pub version: String,
 }
 

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -353,12 +353,6 @@ var (
 
 // ChannelConfig generated struct
 type ChannelConfig struct {
-	ChannelID ID `json:"channel_id"`
-
-	ContractHash Hash `json:"contract_hash"`
-
-	Version string `xdrmaxsize:"200" json:"version"`
-
 	Owner ID `json:"owner"`
 
 	ChannelName string `xdrmaxsize:"200" json:"channel_name"`
@@ -3564,9 +3558,11 @@ var (
 
 // Contract generated struct
 type Contract struct {
-	Contract []byte `json:"contract"`
+	ContractBytes []byte `json:"contract_bytes"`
 
-	Version string `json:"version"`
+	ContractHash Hash `json:"contract_hash"`
+
+	Version string `xdrmaxsize:"100" json:"version"`
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.


### PR DESCRIPTION
It didn't make sense to set the Channel ID, Hash, or Version number in the Channel Config object as these are not able to be modified through Channel Config Update transactions.

- Channel ID cannot be changed.  Execution can pull this value from the Transaction.ChannelID field.

- Version was already stored in the Contract object.
- Hash (Sha3 256) is being moved to the Contract Object and should be set on Transactions to the hash of the contract bytes for verification during execution.

- Renamed the opaque field of Contract to "contractBytes" to make it more clear what this field contains.