### PR TITLE
fix(contract): use abi object in contract field instead of string

### DIFF
--- a/idl/transaction.x
+++ b/idl/transaction.x
@@ -40,8 +40,8 @@ namespace mazzaroth
     // Contract binary bytes.
     opaque contractBytes<>;
 
-    // Contract ABI as JSON string
-    string abi<>;
+    // Contract ABI
+    Abi abi;
 
     // Sha3 256 Hash of the contract bytes, verified on execution
     Hash contractHash;

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -701,7 +701,7 @@ function Call() {
     return new _xdrJsSerialize2.default.Struct(["function", "arguments"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.VarArray(2147483647, Argument)]);
 }
 function Contract() {
-    return new _xdrJsSerialize2.default.Struct(["contractBytes", "abi", "contractHash", "version"], [new _xdrJsSerialize2.default.VarOpaque(2147483647), new _xdrJsSerialize2.default.Str('', 2147483647), Hash(), new _xdrJsSerialize2.default.Str('', 100)]);
+    return new _xdrJsSerialize2.default.Struct(["contractBytes", "abi", "contractHash", "version"], [new _xdrJsSerialize2.default.VarOpaque(2147483647), Abi(), Hash(), new _xdrJsSerialize2.default.Str('', 100)]);
 }
 function Permission() {
     return new _xdrJsSerialize2.default.Struct(["key", "action"], [ID(), PermissionAction()]);

--- a/rust/xdr_generated.rs
+++ b/rust/xdr_generated.rs
@@ -818,8 +818,7 @@ pub struct Contract {
     #[array(var = 2147483647)]
     pub contractBytes: Vec<u8>,
 
-    #[array(var = 2147483647)]
-    pub abi: String,
+    pub abi: Abi,
 
     pub contractHash: Hash,
 

--- a/xdr/xdr_generated.go
+++ b/xdr/xdr_generated.go
@@ -3325,7 +3325,7 @@ var (
 type Contract struct {
 	ContractBytes []byte `json:"contract_bytes"`
 
-	Abi string `json:"abi"`
+	Abi Abi `json:"abi"`
 
 	ContractHash Hash `json:"contract_hash"`
 


### PR DESCRIPTION
Updated the Contract object to store ABI as the ABI object instead of as a JSON String.