### PR TITLE
feat(deps): update xdr-js-serialize and xdr-rs-serialize dependencies to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazzaroth-xdr"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "XDR objects used by Mazzaroth"
 license = "MIT"
@@ -16,8 +16,8 @@ include = [
 ]
 
 [dependencies]
-xdr-rs-serialize = { version = "0.2.5" }
-xdr-rs-serialize-derive = { version = "0.2.5" }
+xdr-rs-serialize = "0.3.0"
+xdr-rs-serialize-derive = "0.3.0"
 json = "0.12.0"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mazzaroth-xdr",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Serialization code for mazzaroth.",
   "main": "js/xdr_generated.js",
   "files": [
@@ -39,6 +39,6 @@
   },
   "dependencies": {
     "markdownlint-cli": "^0.23.2",
-    "xdr-js-serialize": "0.2.0"
+    "xdr-js-serialize": "0.3.0"
   }
 }


### PR DESCRIPTION
# Description

Updated xdr serialization dependencies to v0.3.0. 

This is a breaking change that updates the naming of Union type fields and fixes serialization of null arrays.

Updating version to v0.5.0 with this change.