### PR TITLE
fix(transaction): use boolean keyword to fix generated javascript

### DIFF
--- a/idl/transaction.x
+++ b/idl/transaction.x
@@ -71,7 +71,7 @@ namespace mazzaroth
   {
     AuthorizedAccount account;
 
-    bool authorize;
+    boolean authorize;
   };
 
   enum ActionCategoryType

--- a/js/xdr_generated.js
+++ b/js/xdr_generated.js
@@ -380,7 +380,7 @@ function Contract() {
     return new _xdrJsSerialize2.default.Struct(["contractBytes", "abi", "contractHash", "version"], [new _xdrJsSerialize2.default.VarOpaque(2147483647), Abi(), Hash(), new _xdrJsSerialize2.default.Str('', 100)]);
 }
 function Authorization() {
-    return new _xdrJsSerialize2.default.Struct(["account", "authorize"], [AuthorizedAccount(), bool()]);
+    return new _xdrJsSerialize2.default.Struct(["account", "authorize"], [AuthorizedAccount(), new _xdrJsSerialize2.default.Bool()]);
 }
 function Action() {
     return new _xdrJsSerialize2.default.Struct(["address", "channelID", "nonce", "blockExpirationNumber", "category"], [ID(), ID(), new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.UHyper(), ActionCategory()]);


### PR DESCRIPTION
# Description

We were previously incorrectly using `bool` to specify the authorize field as a boolean for XDR.  This results in xdr-codegen handling this as if it were a custom object type.  It just so happens Rust and Go handle the `bool` type correctly, but JS needs to use the built in XDR Bool type.

By changing the name to `boolean` it gets processed correctly by XDR-Codegen.