### PR TITLE
feat(channel): add new transaction category for channel, restructure idl files

### DIFF
--- a/go-xdr/xdr/xdr_generated.go
+++ b/go-xdr/xdr/xdr_generated.go
@@ -1122,6 +1122,277 @@ var (
 
 // Start typedef section
 
+// End typedef section
+
+// Start struct section
+
+// Call generated struct
+type Call struct {
+	Function string `xdrmaxsize:"256" json:"function"`
+
+	Arguments []Argument `json:"arguments"`
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s Call) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *Call) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*Call)(nil)
+	_ encoding.BinaryUnmarshaler = (*Call)(nil)
+)
+
+// End struct section
+
+// Start enum section
+
+// End enum section
+
+// Start union section
+
+// End union section
+
+// Namespace end mazzaroth
+// Namspace start mazzaroth
+
+// Start typedef section
+
+// End typedef section
+
+// Start struct section
+
+// Channel generated struct
+type Channel struct {
+	ChannelID ID     `json:"channelID"`
+	Name      string `xdrmaxsize:"32" json:"name"`
+
+	Configuration []Config `json:"configuration"`
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s Channel) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *Channel) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*Channel)(nil)
+	_ encoding.BinaryUnmarshaler = (*Channel)(nil)
+)
+
+// End struct section
+
+// Start enum section
+
+// ConfigType generated enum
+type ConfigType int32
+
+const (
+	// ConfigTypeUNKNOWN enum value 0
+	ConfigTypeUNKNOWN ConfigType = 0
+	// ConfigTypeADMIN enum value 1
+	ConfigTypeADMIN ConfigType = 1
+)
+
+// ConfigTypeMap generated enum map
+var ConfigTypeMap = map[int32]string{
+	0: "ConfigTypeUNKNOWN",
+	1: "ConfigTypeADMIN",
+}
+
+// ValidEnum validates a proposed value for this enum.  Implements
+// the Enum interface for ConfigType
+func (s ConfigType) ValidEnum(v int32) bool {
+	_, ok := ConfigTypeMap[v]
+	return ok
+}
+
+// String returns the name of `e`
+func (s ConfigType) String() string {
+	name := ConfigTypeMap[int32(s)]
+	return name
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s ConfigType) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *ConfigType) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*ConfigType)(nil)
+	_ encoding.BinaryUnmarshaler = (*ConfigType)(nil)
+)
+
+// End enum section
+
+// Start union section
+
+// Config generated union
+type Config struct {
+	Type ConfigType
+
+	Admin *[]ID
+}
+
+// SwitchFieldName returns the field name in which this union's
+// discriminant is stored
+func (u Config) SwitchFieldName() string {
+	return "Type"
+}
+
+// ArmForSwitch returns which field name should be used for storing
+// the value for an instance of Config
+func (u Config) ArmForSwitch(sw int32) (string, bool) {
+	switch ConfigType(sw) {
+	case ConfigTypeUNKNOWN:
+		return "", true
+	case ConfigTypeADMIN:
+		return "Admin", true
+	}
+	return "-", false
+}
+
+// NewConfig creates a new Config.
+func NewConfig(aType ConfigType, value interface{}) (result Config, err error) {
+	result.Type = aType
+	switch aType {
+	case ConfigTypeUNKNOWN:
+	case ConfigTypeADMIN:
+
+		tv, ok := value.([]ID)
+
+		if !ok {
+			err = fmt.Errorf("invalid value, must be [object]")
+			return
+		}
+		result.Admin = &tv
+	}
+	return
+}
+
+// MustAdmin retrieves the Admin value from the union,
+// panicing if the value is not set.
+func (u Config) MustAdmin() []ID {
+
+	val, ok := u.GetAdmin()
+	if !ok {
+		panic("arm Admin is not set")
+	}
+
+	return val
+}
+
+// GetAdmin retrieves the Admin value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u Config) GetAdmin() (result []ID, ok bool) {
+
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "Admin" {
+		result = *u.Admin
+		ok = true
+	}
+
+	return
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (u Config) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, u)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (u *Config) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), u)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*Config)(nil)
+	_ encoding.BinaryUnmarshaler = (*Config)(nil)
+)
+
+// MarshalJSON implements json.Marshaler.
+func (u Config) MarshalJSON() ([]byte, error) {
+	temp := struct {
+		Type int32       `json:"type"`
+		Data interface{} `json:"data"`
+	}{}
+
+	temp.Type = int32(u.Type)
+	temp.Data = ""
+	switch u.Type {
+	case ConfigTypeUNKNOWN:
+	case ConfigTypeADMIN:
+		temp.Data = u.Admin
+	default:
+		return nil, fmt.Errorf("invalid union type")
+	}
+
+	return json.Marshal(temp)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (u *Config) UnmarshalJSON(data []byte) error {
+	temp := struct {
+		Type int32 `json:"type"`
+	}{}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	u.Type = ConfigType(temp.Type)
+	switch u.Type {
+	case ConfigTypeUNKNOWN:
+	case ConfigTypeADMIN:
+		response := struct {
+			Admin []ID `json:"data"`
+		}{}
+		err := json.Unmarshal(data, &response)
+		if err != nil {
+			return err
+		}
+		u.Admin = &response.Admin
+	default:
+		return fmt.Errorf("invalid union type")
+	}
+
+	return nil
+}
+
+// End union section
+
+// Namespace end mazzaroth
+// Namspace start mazzaroth
+
+// Start typedef section
+
 // Signature generated typedef
 type Signature [64]byte
 
@@ -1321,6 +1592,52 @@ var (
 
 // Start struct section
 
+// Contract generated struct
+type Contract struct {
+	Version      string `xdrmaxsize:"100" json:"version"`
+	Abi          Abi    `json:"abi"`
+	ContractHash Hash   `json:"contractHash"`
+
+	ContractBytes []byte `json:"contractBytes"`
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (s Contract) MarshalBinary() ([]byte, error) {
+	b := new(bytes.Buffer)
+	_, err := Marshal(b, s)
+	return b.Bytes(), err
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (s *Contract) UnmarshalBinary(inp []byte) error {
+	_, err := Unmarshal(bytes.NewReader(inp), s)
+	return err
+}
+
+var (
+	_ encoding.BinaryMarshaler   = (*Contract)(nil)
+	_ encoding.BinaryUnmarshaler = (*Contract)(nil)
+)
+
+// End struct section
+
+// Start enum section
+
+// End enum section
+
+// Start union section
+
+// End union section
+
+// Namespace end mazzaroth
+// Namspace start mazzaroth
+
+// Start typedef section
+
+// End typedef section
+
+// Start struct section
+
 // Receipt generated struct
 type Receipt struct {
 	TransactionID ID         `json:"transactionID"`
@@ -1366,59 +1683,6 @@ var (
 // End typedef section
 
 // Start struct section
-
-// Call generated struct
-type Call struct {
-	Function string `xdrmaxsize:"256" json:"function"`
-
-	Arguments []Argument `json:"arguments"`
-}
-
-// MarshalBinary implements encoding.BinaryMarshaler.
-func (s Call) MarshalBinary() ([]byte, error) {
-	b := new(bytes.Buffer)
-	_, err := Marshal(b, s)
-	return b.Bytes(), err
-}
-
-// UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *Call) UnmarshalBinary(inp []byte) error {
-	_, err := Unmarshal(bytes.NewReader(inp), s)
-	return err
-}
-
-var (
-	_ encoding.BinaryMarshaler   = (*Call)(nil)
-	_ encoding.BinaryUnmarshaler = (*Call)(nil)
-)
-
-// Contract generated struct
-type Contract struct {
-	Version      string `xdrmaxsize:"100" json:"version"`
-	Owner        ID     `json:"owner"`
-	Abi          Abi    `json:"abi"`
-	ContractHash Hash   `json:"contractHash"`
-
-	ContractBytes []byte `json:"contractBytes"`
-}
-
-// MarshalBinary implements encoding.BinaryMarshaler.
-func (s Contract) MarshalBinary() ([]byte, error) {
-	b := new(bytes.Buffer)
-	_, err := Marshal(b, s)
-	return b.Bytes(), err
-}
-
-// UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (s *Contract) UnmarshalBinary(inp []byte) error {
-	_, err := Unmarshal(bytes.NewReader(inp), s)
-	return err
-}
-
-var (
-	_ encoding.BinaryMarshaler   = (*Contract)(nil)
-	_ encoding.BinaryUnmarshaler = (*Contract)(nil)
-)
 
 // Data generated struct
 type Data struct {
@@ -1491,6 +1755,8 @@ const (
 	CategoryTypePAUSE CategoryType = 3
 	// CategoryTypeDELETE enum value 4
 	CategoryTypeDELETE CategoryType = 4
+	// CategoryTypeCHANNEL enum value 5
+	CategoryTypeCHANNEL CategoryType = 5
 )
 
 // CategoryTypeMap generated enum map
@@ -1500,6 +1766,7 @@ var CategoryTypeMap = map[int32]string{
 	2: "CategoryTypeDEPLOY",
 	3: "CategoryTypePAUSE",
 	4: "CategoryTypeDELETE",
+	5: "CategoryTypeCHANNEL",
 }
 
 // ValidEnum validates a proposed value for this enum.  Implements
@@ -1545,6 +1812,8 @@ type Category struct {
 	Contract *Contract
 
 	Pause *bool
+
+	Channel *Channel
 }
 
 // SwitchFieldName returns the field name in which this union's
@@ -1567,6 +1836,8 @@ func (u Category) ArmForSwitch(sw int32) (string, bool) {
 		return "Pause", true
 	case CategoryTypeDELETE:
 		return "", true
+	case CategoryTypeCHANNEL:
+		return "Channel", true
 	}
 	return "-", false
 }
@@ -1601,6 +1872,14 @@ func NewCategory(aType CategoryType, value interface{}) (result Category, err er
 		}
 		result.Pause = &tv
 	case CategoryTypeDELETE:
+	case CategoryTypeCHANNEL:
+		tv, ok := value.(Channel)
+
+		if !ok {
+			err = fmt.Errorf("invalid value, must be [object]")
+			return
+		}
+		result.Channel = &tv
 	}
 	return
 }
@@ -1683,6 +1962,32 @@ func (u Category) GetPause() (result bool, ok bool) {
 	return
 }
 
+// MustChannel retrieves the Channel value from the union,
+// panicing if the value is not set.
+func (u Category) MustChannel() Channel {
+
+	val, ok := u.GetChannel()
+	if !ok {
+		panic("arm Channel is not set")
+	}
+
+	return val
+}
+
+// GetChannel retrieves the Channel value from the union,
+// returning ok if the union's switch indicated the value is valid.
+func (u Category) GetChannel() (result Channel, ok bool) {
+
+	armName, _ := u.ArmForSwitch(int32(u.Type))
+
+	if armName == "Channel" {
+		result = *u.Channel
+		ok = true
+	}
+
+	return
+}
+
 // MarshalBinary implements encoding.BinaryMarshaler.
 func (u Category) MarshalBinary() ([]byte, error) {
 	b := new(bytes.Buffer)
@@ -1719,6 +2024,8 @@ func (u Category) MarshalJSON() ([]byte, error) {
 	case CategoryTypePAUSE:
 		temp.Data = u.Pause
 	case CategoryTypeDELETE:
+	case CategoryTypeCHANNEL:
+		temp.Data = u.Channel
 	default:
 		return nil, fmt.Errorf("invalid union type")
 	}
@@ -1766,6 +2073,15 @@ func (u *Category) UnmarshalJSON(data []byte) error {
 		}
 		u.Pause = &response.Pause
 	case CategoryTypeDELETE:
+	case CategoryTypeCHANNEL:
+		response := struct {
+			Channel Channel `json:"data"`
+		}{}
+		err := json.Unmarshal(data, &response)
+		if err != nil {
+			return err
+		}
+		u.Channel = &response.Channel
 	default:
 		return fmt.Errorf("invalid union type")
 	}

--- a/idl/call.x
+++ b/idl/call.x
@@ -1,0 +1,14 @@
+
+namespace mazzaroth
+{
+  // A transaction that calls a function on a user defined contract.
+  struct Call
+  {
+    // Contract function to execute.
+    string function<256>;
+
+    // Arguments to the contract function. The serialization format is defined
+    // by the contract itself.
+    Argument arguments<>;
+  };
+}

--- a/idl/channel.x
+++ b/idl/channel.x
@@ -1,0 +1,26 @@
+
+namespace mazzaroth
+{
+  struct Channel
+  {
+    ID channelID;
+
+    string name<32>;
+
+    Config configuration<>;
+  };
+
+  enum ConfigType
+  {
+    UNKNOWN = 0,
+    ADMIN = 1
+  };
+
+  union Config switch (ConfigType Type)
+  {
+    case UNKNOWN:
+      void;
+    case ADMIN:
+      ID admin<8>;
+  };
+}

--- a/idl/contract.x
+++ b/idl/contract.x
@@ -1,0 +1,18 @@
+namespace mazzaroth
+{
+  // An update transaction that provides a contract as a wasm binary.
+  struct Contract
+  {
+    // Version number of the contract, specified by owner
+    string version<100>;
+
+    // Contract ABI
+    Abi abi;
+
+    // Sha3 256 Hash of the contract bytes, verified on execution
+    Hash contractHash;
+
+    // Contract binary bytes.
+    opaque contractBytes<>;
+  };
+}

--- a/idl/transaction.x
+++ b/idl/transaction.x
@@ -1,43 +1,14 @@
 
 namespace mazzaroth
 {
-  // A transaction that calls a function on a user defined contract.
-  struct Call
-  {
-    // Contract function to execute.
-    string function<256>;
-
-    // Arguments to the contract function. The serialization format is defined
-    // by the contract itself.
-    Argument arguments<>;
-  };
-
-  // An update transaction that provides a contract as a wasm binary.
-  struct Contract
-  {
-    // Version number of the contract, specified by owner
-    string version<100>;
-
-     // Public Key ID of the channel owner. Only owner can change this to transfer ownership of channel
-    ID owner;
-   
-    // Contract ABI
-    Abi abi;
-
-    // Sha3 256 Hash of the contract bytes, verified on execution
-    Hash contractHash;
-
-    // Contract binary bytes.
-    opaque contractBytes<>;
-  }
-
   enum CategoryType
   {
     UNKNOWN = 0,
     CALL = 1,
     DEPLOY = 2,
     PAUSE = 3,
-    DELETE = 4
+    DELETE = 4,
+    CHANNEL = 5
   };
 
   union Category switch (CategoryType Type)
@@ -52,6 +23,9 @@ namespace mazzaroth
       boolean pause;
     case DELETE:
       void;
+    case CHANNEL:
+      // Channel
+      Channel channel;
   };
 
   // The data of a transaction

--- a/js-xdr/xdr_generated.js
+++ b/js-xdr/xdr_generated.js
@@ -14,15 +14,18 @@ exports.Response = Response;
 exports.Block = Block;
 exports.BlockHeader = BlockHeader;
 exports.BlockHeight = BlockHeight;
+exports.Call = Call;
+exports.Channel = Channel;
+exports.ConfigType = ConfigType;
+exports.Config = Config;
 exports.Signature = Signature;
 exports.ID = ID;
 exports.Hash = Hash;
 exports.Argument = Argument;
 exports.StatusInfo = StatusInfo;
 exports.Status = Status;
-exports.Receipt = Receipt;
-exports.Call = Call;
 exports.Contract = Contract;
+exports.Receipt = Receipt;
 exports.Data = Data;
 exports.Transaction = Transaction;
 exports.CategoryType = CategoryType;
@@ -181,6 +184,62 @@ function BlockHeight() {
 // Namespace start mazzaroth
 
 // Start typedef section
+// End typedef section
+
+// Start struct section
+function Call() {
+    return new _xdrJsSerialize2.default.Struct(["function", "arguments"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.VarArray(2147483647, Argument)]);
+}
+// End struct section
+
+// Start enum section
+
+// End enum section
+
+// Start union section
+
+// End union section
+
+// End namespace mazzaroth
+// Namespace start mazzaroth
+
+// Start typedef section
+// End typedef section
+
+// Start struct section
+function Channel() {
+    return new _xdrJsSerialize2.default.Struct(["channelID", "name", "configuration"], [ID(), new _xdrJsSerialize2.default.Str('', 32), new _xdrJsSerialize2.default.VarArray(2147483647, Config)]);
+}
+// End struct section
+
+// Start enum section
+function ConfigType() {
+    return new _xdrJsSerialize2.default.Enum({
+        0: "UNKNOWN",
+        1: "ADMIN"
+    });
+}
+
+// End enum section
+
+// Start union section
+
+function Config() {
+    return new _xdrJsSerialize2.default.Union(ConfigType(), {
+        "UNKNOWN": () => {
+            return new _xdrJsSerialize2.default.Void();
+        },
+        "ADMIN": () => {
+            return new _xdrJsSerialize2.default.VarArray(8, ID);
+        }
+    });
+}
+// End union section
+
+// End namespace mazzaroth
+// Namespace start mazzaroth
+
+// Start typedef section
 function Signature() {
     return new _xdrJsSerialize2.default.FixedOpaque(64);
 }
@@ -225,6 +284,26 @@ function Status() {
 // End typedef section
 
 // Start struct section
+function Contract() {
+    return new _xdrJsSerialize2.default.Struct(["version", "abi", "contractHash", "contractBytes"], [new _xdrJsSerialize2.default.Str('', 100), Abi(), Hash(), new _xdrJsSerialize2.default.VarOpaque(2147483647)]);
+}
+// End struct section
+
+// Start enum section
+
+// End enum section
+
+// Start union section
+
+// End union section
+
+// End namespace mazzaroth
+// Namespace start mazzaroth
+
+// Start typedef section
+// End typedef section
+
+// Start struct section
 function Receipt() {
     return new _xdrJsSerialize2.default.Struct(["transactionID", "status", "stateRoot", "result", "statusInfo"], [ID(), Status(), Hash(), new _xdrJsSerialize2.default.Str('', 2147483647), StatusInfo()]);
 }
@@ -245,12 +324,6 @@ function Receipt() {
 // End typedef section
 
 // Start struct section
-function Call() {
-    return new _xdrJsSerialize2.default.Struct(["function", "arguments"], [new _xdrJsSerialize2.default.Str('', 256), new _xdrJsSerialize2.default.VarArray(2147483647, Argument)]);
-}
-function Contract() {
-    return new _xdrJsSerialize2.default.Struct(["version", "owner", "abi", "contractHash", "contractBytes"], [new _xdrJsSerialize2.default.Str('', 100), ID(), Abi(), Hash(), new _xdrJsSerialize2.default.VarOpaque(2147483647)]);
-}
 function Data() {
     return new _xdrJsSerialize2.default.Struct(["channelID", "nonce", "blockExpirationNumber", "category"], [ID(), new _xdrJsSerialize2.default.UHyper(), new _xdrJsSerialize2.default.UHyper(), Category()]);
 }
@@ -266,7 +339,8 @@ function CategoryType() {
         1: "CALL",
         2: "DEPLOY",
         3: "PAUSE",
-        4: "DELETE"
+        4: "DELETE",
+        5: "CHANNEL"
     });
 }
 
@@ -290,6 +364,9 @@ function Category() {
         },
         "DELETE": () => {
             return new _xdrJsSerialize2.default.Void();
+        },
+        "CHANNEL": () => {
+            return Channel();
         }
     });
 }

--- a/rust-xdr/xdr_generated.rs
+++ b/rust-xdr/xdr_generated.rs
@@ -201,6 +201,75 @@ pub struct BlockHeight {
 
 // Start typedef section
 
+// End typedef section
+
+// Start struct section
+
+#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
+pub struct Call {
+    #[array(var = 256)]
+    pub function: String,
+    #[array(var = 2147483647)]
+    pub arguments: Vec<Argument>,
+}
+// End struct section
+
+// Start union section
+
+// End union section
+
+// Namespace end mazzaroth
+// Namespace start mazzaroth
+
+// Start typedef section
+
+// End typedef section
+
+// Start struct section
+
+#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
+pub struct Channel {
+    pub channelID: ID,
+    #[array(var = 32)]
+    pub name: String,
+    #[array(var = 2147483647)]
+    pub configuration: Vec<Config>,
+}
+// End struct section
+
+#[derive(PartialEq, Clone, Debug, XDROut, XDRIn)]
+pub enum ConfigType {
+    UNKNOWN = 0,
+    ADMIN = 1,
+}
+
+impl Default for ConfigType {
+    fn default() -> Self {
+        ConfigType::UNKNOWN
+    }
+}
+// Start union section
+
+#[derive(PartialEq, Clone, Debug, XDROut, XDRIn)]
+pub enum Config {
+    UNKNOWN(()),
+
+    #[array(var = 8)]
+    ADMIN(Vec<ID>),
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config::UNKNOWN(())
+    }
+}
+// End union section
+
+// Namespace end mazzaroth
+// Namespace start mazzaroth
+
+// Start typedef section
+
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Signature {
     #[array(fixed = 64)]
@@ -259,6 +328,30 @@ impl Default for Status {
 // Start struct section
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
+pub struct Contract {
+    #[array(var = 100)]
+    pub version: String,
+    pub abi: Abi,
+    pub contractHash: Hash,
+    #[array(var = 2147483647)]
+    pub contractBytes: Vec<u8>,
+}
+// End struct section
+
+// Start union section
+
+// End union section
+
+// Namespace end mazzaroth
+// Namespace start mazzaroth
+
+// Start typedef section
+
+// End typedef section
+
+// Start struct section
+
+#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Receipt {
     pub transactionID: ID,
     pub status: Status,
@@ -283,25 +376,6 @@ pub struct Receipt {
 // Start struct section
 
 #[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
-pub struct Call {
-    #[array(var = 256)]
-    pub function: String,
-    #[array(var = 2147483647)]
-    pub arguments: Vec<Argument>,
-}
-
-#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
-pub struct Contract {
-    #[array(var = 100)]
-    pub version: String,
-    pub owner: ID,
-    pub abi: Abi,
-    pub contractHash: Hash,
-    #[array(var = 2147483647)]
-    pub contractBytes: Vec<u8>,
-}
-
-#[derive(PartialEq, Clone, Default, Debug, XDROut, XDRIn)]
 pub struct Data {
     pub channelID: ID,
     pub nonce: u64,
@@ -324,6 +398,7 @@ pub enum CategoryType {
     DEPLOY = 2,
     PAUSE = 3,
     DELETE = 4,
+    CHANNEL = 5,
 }
 
 impl Default for CategoryType {
@@ -343,6 +418,7 @@ pub enum Category {
     PAUSE(bool),
 
     DELETE(()),
+    CHANNEL(Channel),
 }
 
 impl Default for Category {


### PR DESCRIPTION
# Description

This PR is a proposal for adding the new Channel transaction type to set and update channel configuration.

- Remove the owner field from Contract
- Add Channel object along with Transaction type to modify it
- Channel contains the ID, a string name, as well as a list of config objects.
- Config is a union with an example type of `Admin` added which is a list of IDs with admin privilege on the Channel