### PR TITLE
deps(xdr-rs-serialize): update to v0.3.1 to support new error types and fix deserialization panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazzaroth-xdr"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Kochavalabs <dev@mazzaroth.io>"]
 description = "XDR objects used by Mazzaroth"
 license = "MIT"
@@ -16,8 +16,8 @@ include = [
 ]
 
 [dependencies]
-xdr-rs-serialize = "0.3.0"
-xdr-rs-serialize-derive = "0.3.0"
+xdr-rs-serialize = "0.3.1"
+xdr-rs-serialize-derive = "0.3.1"
 json = "0.12.0"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mazzaroth-xdr",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Serialization code for mazzaroth.",
   "main": "js-xdr/xdr_generated.js",
   "files": [


### PR DESCRIPTION
# Description

Updating the xdr-rs-serialize dependencies.
This update added error types and replaced several generated panics to instead return errors which provides better feedback on execution when a serialization error occurs.